### PR TITLE
Fix lint warnings in sales components

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,35 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import App from './App';
+import AuthProvider from './contexts/AuthContext';
+import { ConfigProvider } from './contexts/ConfigContext';
+import { ClientProvider } from './contexts/ClientContext';
+import { CartProvider } from './contexts/CartContext';
+import PinProvider from './contexts/PinContext';
+import { PrimeReactProvider } from 'primereact/api';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('shows license modal on first load', async () => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve({ version: '1' }) })
+  );
+
+  render(
+    <PrimeReactProvider>
+      <AuthProvider>
+        <MemoryRouter initialEntries={['/penaprieta8']}>
+          <ConfigProvider>
+            <ClientProvider>
+              <CartProvider>
+                <PinProvider>
+                  <App />
+                </PinProvider>
+              </CartProvider>
+            </ClientProvider>
+          </ConfigProvider>
+        </MemoryRouter>
+      </AuthProvider>
+    </PrimeReactProvider>
+  );
+
+  expect(await screen.findByText(/Ingrese su Licencia/i)).toBeInTheDocument();
 });

--- a/src/components/ProductSearch/ProductSearchCard.jsx
+++ b/src/components/ProductSearch/ProductSearchCard.jsx
@@ -44,6 +44,7 @@ const ProductSearchCard = ({
     forceAdd = false,
     quantity = 1
   ) => {
+    setIsDevolution(false);
     onAddProduct(
       product,
       stockQuantity,
@@ -59,9 +60,7 @@ const ProductSearchCard = ({
     groupedProducts,
     isLoading,
     confirmModalOpen,
-    productToConfirm,
     handleSearch,
-    addProductToCart,
     handleCancelAdd,
     handleConfirmAdd,
     foreignConfirmDialogOpen,

--- a/src/components/Sales/SalesCard.jsx
+++ b/src/components/Sales/SalesCard.jsx
@@ -45,14 +45,12 @@ function SalesCard({
   const {
     selectedClient,
     setSelectedClient,
-    selectedAddress,
     setSelectedAddress,
     resetToDefaultClientAndAddress,
   } = useContext(ClientContext);
   const {
     isDevolution,
     setIsDevolution,
-    isDiscount,
     setIsDiscount,
     setOriginalPaymentMethods,
     setOriginalPaymentAmounts,

--- a/src/components/Sales/SalesCardActions.jsx
+++ b/src/components/Sales/SalesCardActions.jsx
@@ -68,12 +68,8 @@ function SalesCardActions({
   const [isPinModalOpen, setIsPinModalOpen] = useState(false);
   const [isDiscountModalOpen, setIsDiscountModalOpen] = useState(false);
   const [isFinalSaleModalOpen, setFinalSaleModalOpen] = useState(false);
-  const [ticketModalOpen, setTicketModalOpen] = useState(false);
   const [ticketOrderId, setTicketOrderId] = useState(null);
-  const [ticketOrderOrigin, setTicketOrderOrigin] = useState(null);
-  const [printOnOpen, setPrintOnOpen] = useState(false);
   const [giftTicket, setGiftTicket] = useState(false);
-  const [giftTicketTM, setGiftTicketTM] = useState(false);
   const [cartRuleModalOpen, setCartRuleModalOpen] = useState(false);
   const [newCartRuleCode, setNewCartRuleCode] = useState(null);
   const [isManualModalOpen, setIsManualModalOpen] = useState(false);
@@ -279,11 +275,7 @@ function SalesCardActions({
         }) => {
           showAlert("Venta finalizada correctamente", true);
           setTicketOrderId(orderId);
-          setTicketOrderOrigin(orderOrigin);
-          setGiftTicketTM(giftTicket);
           setChangeAmount(changeAmount);
-          setTicketModalOpen(true);
-          setPrintOnOpen(print);
 
           // Si se generó un vale descuento, activar el modal (no mostrar botón en el layout principal)
           if (newCartRuleCode) {


### PR DESCRIPTION
## Summary
- mark new product additions as not devolutions
- drop unused state setters in Sales card components

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68544f8d9488833190a2036509e67970