### PR TITLE
Update existing tests for current components

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,44 @@
 import { render, screen } from '@testing-library/react';
-import App from './App';
+import { MemoryRouter } from 'react-router-dom';
+import AuthProvider from './contexts/AuthContext';
+import LoginPage from './components/pages/LoginPage';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+beforeEach(() => {
+  localStorage.setItem(
+    'licenseData',
+    JSON.stringify({ licenseKey: 'abc', id_shop: 11, url: 'penaprieta8' })
+  );
+  global.fetch = jest.fn((url) => {
+    if (url.includes('license_check')) {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({ status: 'OK', message: 'License actived' }),
+      });
+    }
+    if (url.includes('employees')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  });
+});
+
+afterEach(() => {
+  localStorage.clear();
+  jest.resetAllMocks();
+});
+
+test('renders login heading for shop', async () => {
+  render(
+    <MemoryRouter>
+      <AuthProvider>
+        <LoginPage shopRoute="penaprieta8" />
+      </AuthProvider>
+    </MemoryRouter>
+  );
+
+  const heading = await screen.findByRole('heading', {
+    name: /Iniciar Sesión/i,
+  });
+  expect(heading).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- replace CRA placeholder test with a test for LoginPage
- mock API calls and local storage to render LoginPage

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6854f7845b588331b76f3a4eb6ee4816