### PR TITLE
Centralize date formatting utilities

### DIFF
--- a/src/components/modals/cashRegister/CloseCashRegisterForm.jsx
+++ b/src/components/modals/cashRegister/CloseCashRegisterForm.jsx
@@ -17,6 +17,7 @@ import { ConfigContext } from "../../../contexts/ConfigContext";
 import { Dialog } from "primereact/dialog";
 import { generateSalesPdf } from "../../../utils/generateSalesPdf";
 import "jspdf-autotable";
+import { formatLongDate } from "../../../utils/dateUtils";
 
 function formatNumber(value) {
   return isNaN(Number(value)) || value === "" ? "0" : value;
@@ -341,17 +342,7 @@ const CloseCashRegisterForm = ({ onClose }) => {
         total,
         iva,
       };
-      const formatDate = (dateStr) => {
-        const d = new Date(dateStr);
-        const weekday = d.toLocaleDateString("es-ES", { weekday: "long" });
-        const day = d.toLocaleDateString("es-ES", { day: "2-digit" });
-        const month = d.toLocaleDateString("es-ES", { month: "long" });
-        const year = d.toLocaleDateString("es-ES", { year: "numeric" });
-        const capitalizedWeekday =
-          weekday.charAt(0).toUpperCase() + weekday.slice(1);
-        return `${capitalizedWeekday} ${day} de ${month} de ${year}`;
-      };
-      const formattedDate = formatDate(reportDateAdd);
+      const formattedDate = formatLongDate(reportDateAdd);
       const pdfName = `${closureData.shop_name} - ${formattedDate}`;
       const result = generateSalesPdf(
         saleReportData,

--- a/src/components/modals/cashRegister/ListCashRegisterModal.jsx
+++ b/src/components/modals/cashRegister/ListCashRegisterModal.jsx
@@ -11,6 +11,7 @@ import { useEmployeesDictionary } from "../../../hooks/useEmployeesDictionary";
 import { ConfigContext } from "../../../contexts/ConfigContext";
 import { AuthContext } from "../../../contexts/AuthContext";
 import { generateClosureTicket } from "../../../utils/ticket";
+import { formatLongDate } from "../../../utils/dateUtils";
 
 const ListCashRegisterModal = ({ isOpen, onClose, inlineMode = false }) => {
   const [sessions, setSessions] = useState([]);
@@ -100,17 +101,7 @@ const ListCashRegisterModal = ({ isOpen, onClose, inlineMode = false }) => {
         total,
         iva,
       };
-      const formatDate = (dateStr) => {
-        const d = new Date(dateStr);
-        const weekday = d.toLocaleDateString("es-ES", { weekday: "long" });
-        const day = d.toLocaleDateString("es-ES", { day: "2-digit" });
-        const month = d.toLocaleDateString("es-ES", { month: "long" });
-        const year = d.toLocaleDateString("es-ES", { year: "numeric" });
-        const capitalizedWeekday =
-          weekday.charAt(0).toUpperCase() + weekday.slice(1);
-        return `${capitalizedWeekday} ${day} de ${month} de ${year}`;
-      };
-      const formattedDate = formatDate(date_add);
+      const formattedDate = formatLongDate(date_add);
       const pdfName = `${closureData.shop_name} - ${formattedDate}`;
       const result = generateSalesPdf(
         saleReportData,

--- a/src/components/modals/online/OnlineOrdersModal.jsx
+++ b/src/components/modals/online/OnlineOrdersModal.jsx
@@ -14,6 +14,7 @@ import { Toast } from "primereact/toast";
 import { TabView, TabPanel } from "primereact/tabview";
 import getApiBaseUrl from "../../../utils/getApiBaseUrl";
 import useProductSearch from "../../../hooks/useProductSearch";
+import { formatDate } from "../../../utils/dateUtils";
 import { AuthContext } from "../../../contexts/AuthContext";
 import ActionResultDialog from "../../common/ActionResultDialog";
 import generateTicket from "../../../utils/ticket";
@@ -63,20 +64,6 @@ const OnlineOrdersModal = ({ isOpen, onClose }) => {
     selectedClient,
   });
 
-  const formatDate = (dateString) => {
-    if (!dateString) return "";
-    const dateObj = new Date(dateString);
-    if (isNaN(dateObj)) return dateString;
-
-    const dd = String(dateObj.getDate()).padStart(2, "0");
-    const mm = String(dateObj.getMonth() + 1).padStart(2, "0");
-    const yyyy = dateObj.getFullYear();
-
-    const hh = String(dateObj.getHours()).padStart(2, "0");
-    const min = String(dateObj.getMinutes()).padStart(2, "0");
-
-    return `${dd}-${mm}-${yyyy} ${hh}:${min}`;
-  };
 
   const loadOnlineOrders = useCallback(async () => {
     try {

--- a/src/components/modals/transfers/TransfersModal.jsx
+++ b/src/components/modals/transfers/TransfersModal.jsx
@@ -22,6 +22,7 @@ import { useEmployeesDictionary } from "../../../hooks/useEmployeesDictionary";
 import { ProgressSpinner } from "primereact/progressspinner";
 import { ConfirmDialog, confirmDialog } from "primereact/confirmdialog";
 import { Toast } from "primereact/toast";
+import { formatDate } from "../../../utils/dateUtils";
 
 // Definir filtros iniciales para global y para cada columna
 const initialFilters = {
@@ -136,14 +137,6 @@ const TransfersModal = ({ isOpen, onClose }) => {
     setLoading(true);
     setSelectedMovements([]);
 
-    const formatDate = (dateStr) => {
-      if (!dateStr) return dateStr;
-      const [datePart, timePart] = dateStr.split(" ");
-      if (!datePart || !timePart) return dateStr;
-      const [year, month, day] = datePart.split("-");
-      const [hour, minute] = timePart.split(":");
-      return `${day}-${month}-${year} ${hour}:${minute}`;
-    };
 
     try {
       const data = await apiFetch(`${API_BASE_URL}/get_warehouse_movements`, {

--- a/src/components/reports/SalesReportSearch.jsx
+++ b/src/components/reports/SalesReportSearch.jsx
@@ -8,6 +8,7 @@ import { DataTable } from "primereact/datatable";
 import { Column } from "primereact/column";
 import getApiBaseUrl from "../../utils/getApiBaseUrl";
 import "jspdf-autotable";
+import { formatDate } from "../../utils/dateUtils";
 
 const SalesReportSearch = ({ initialDateFrom, initialDateTo }) => {
   const apiFetch = useApiFetch();
@@ -60,23 +61,6 @@ const SalesReportSearch = ({ initialDateFrom, initialDateTo }) => {
       payment: order.payment,
     }))
   );
-
-  // Función para formatear fecha => dd-mm-yyyy hh:mm
-  const formatDate = (dateString) => {
-    if (!dateString) return "";
-    const dateObj = new Date(dateString);
-    if (isNaN(dateObj)) return dateString; // Si no es fecha válida, devuelves la cadena original
-
-    const dd = String(dateObj.getDate()).padStart(2, "0");
-    const mm = String(dateObj.getMonth() + 1).padStart(2, "0");
-    const yyyy = dateObj.getFullYear();
-
-    const hh = String(dateObj.getHours()).padStart(2, "0");
-    const min = String(dateObj.getMinutes()).padStart(2, "0");
-
-    return `${dd}-${mm}-${yyyy} ${hh}:${min}`;
-  };
-
   // Mostrar cliente => "TPV" si coincide con configData.id_customer_default, en otro caso el id
   const getCustomerDisplay = (id_customer) => {
     if (
@@ -100,18 +84,15 @@ const SalesReportSearch = ({ initialDateFrom, initialDateTo }) => {
     return methods.join(", ");
   };
 
-  // Calcular totales globales
-  const totalCash = orders.reduce(
-    (acc, order) => acc + (order.total_cash || 0),
-    0
-  );
-  const totalCard = orders.reduce(
-    (acc, order) => acc + (order.total_card || 0),
-    0
-  );
-  const totalBizum = orders.reduce(
-    (acc, order) => acc + (order.total_bizum || 0),
-    0
+  // Calcular totales globales en una sola iteración
+  const { totalCash, totalCard, totalBizum } = orders.reduce(
+    (acc, order) => {
+      acc.totalCash += order.total_cash || 0;
+      acc.totalCard += order.total_card || 0;
+      acc.totalBizum += order.total_bizum || 0;
+      return acc;
+    },
+    { totalCash: 0, totalCard: 0, totalBizum: 0 }
   );
   const showBizumColumn = totalBizum > 0;
 

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -1,0 +1,23 @@
+export function formatDate(dateString) {
+  if (!dateString) return "";
+  const dateObj = new Date(dateString);
+  if (isNaN(dateObj)) return dateString;
+  const dd = String(dateObj.getDate()).padStart(2, "0");
+  const mm = String(dateObj.getMonth() + 1).padStart(2, "0");
+  const yyyy = dateObj.getFullYear();
+  const hh = String(dateObj.getHours()).padStart(2, "0");
+  const min = String(dateObj.getMinutes()).padStart(2, "0");
+  return `${dd}-${mm}-${yyyy} ${hh}:${min}`;
+}
+
+export function formatLongDate(dateStr) {
+  if (!dateStr) return "";
+  const d = new Date(dateStr);
+  if (isNaN(d)) return dateStr;
+  const weekday = d.toLocaleDateString("es-ES", { weekday: "long" });
+  const day = d.toLocaleDateString("es-ES", { day: "2-digit" });
+  const month = d.toLocaleDateString("es-ES", { month: "long" });
+  const year = d.toLocaleDateString("es-ES", { year: "numeric" });
+  const capitalizedWeekday = weekday.charAt(0).toUpperCase() + weekday.slice(1);
+  return `${capitalizedWeekday} ${day} de ${month} de ${year}`;
+}

--- a/src/utils/generateSalesPdf.js
+++ b/src/utils/generateSalesPdf.js
@@ -1,5 +1,6 @@
 import jsPDF from "jspdf";
 import "jspdf-autotable";
+import { formatLongDate } from "./dateUtils";
 
 export const generateSalesPdf = (data, shopName, closureData, configData) => {
   try {
@@ -7,19 +8,13 @@ export const generateSalesPdf = (data, shopName, closureData, configData) => {
     const margin = 40;
     let yPos = margin;
 
-    // Función auxiliar para formatear fecha
-    function formatDateTime(date) {
+    // Función auxiliar para formatear fecha y hora
+    const formatDateTime = (date) => {
       const d = new Date(date);
-      const weekday = d.toLocaleDateString("es-ES", { weekday: "long" });
-      const day = d.toLocaleDateString("es-ES", { day: "2-digit" });
-      const month = d.toLocaleDateString("es-ES", { month: "long" });
-      const year = d.toLocaleDateString("es-ES", { year: "numeric" });
-      const capitalizedWeekday =
-        weekday.charAt(0).toUpperCase() + weekday.slice(1);
       const hh = ("0" + d.getHours()).slice(-2);
       const min = ("0" + d.getMinutes()).slice(-2);
-      return `${hh}:${min} - ${capitalizedWeekday} ${day} de ${month} de ${year}`;
-    }
+      return `${hh}:${min} - ${formatLongDate(d)}`;
+    };
 
     doc.setFontSize(18);
     doc.text(`Reporte de ventas: ${shopName}`, margin, yPos);


### PR DESCRIPTION
## Summary
- add `dateUtils` with shared `formatDate` and `formatLongDate`
- use new utilities across components and PDF generator
- streamline sales report totals calculation

## Testing
- `npm test --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68550069b3bc8331a6594b6dfcf749d5