### PR TITLE
Refactor product search

### DIFF
--- a/src/components/ProductSearch/ProductSearchCard.jsx
+++ b/src/components/ProductSearch/ProductSearchCard.jsx
@@ -61,6 +61,7 @@ const ProductSearchCard = ({
     confirmModalOpen,
     productToConfirm,
     handleSearch,
+    fetchControlStock,
     addProductToCart,
     handleCancelAdd,
     handleConfirmAdd,
@@ -171,7 +172,21 @@ const ProductSearchCard = ({
 
   const handleKeyDown = async (event) => {
     if (event.key !== "Enter") return;
-    await handleSearch(searchTerm);
+    const groups = await handleSearch(searchTerm);
+    if (groups && groups.length) {
+      const eans = new Set();
+      groups.forEach((g) =>
+        g.combinations.forEach((c) => {
+          const code = c.id_product_attribute
+            ? c.ean13_combination
+            : c.ean13_combination_0;
+          if (code) eans.add(code);
+        })
+      );
+      for (const ean of eans) {
+        await fetchControlStock(ean);
+      }
+    }
     setSearchTerm("");
     setTimeout(() => {
       if (!disableAutoFocus && searchInputRef.current) {

--- a/src/components/ProductSearch/ProductSearchCard.jsx
+++ b/src/components/ProductSearch/ProductSearchCard.jsx
@@ -184,7 +184,11 @@ const ProductSearchCard = ({
         })
       );
       for (const ean of eans) {
-        await fetchControlStock(ean);
+        try {
+          await fetchControlStock(ean);
+        } catch (err) {
+          console.error("Error loading control stock", err);
+        }
       }
     }
     setSearchTerm("");

--- a/src/hooks/useProductSearch.jsx
+++ b/src/hooks/useProductSearch.jsx
@@ -131,7 +131,9 @@ const useProductSearch = ({
             const matches = list.filter(
               (cs) => Number(cs.id_shop) === Number(stock.id_shop)
             );
-            if (matches.length === 0) return stock;
+            if (matches.length === 0) {
+              return { ...stock, control_stock: [] };
+            }
             return {
               ...stock,
               control_stock: matches.map((cs) => ({
@@ -371,7 +373,8 @@ const useProductSearch = ({
             body: JSON.stringify({ ean13: eanCode }),
           }
         );
-        const controlMatch = controlList.find(
+        const matchList = Array.isArray(controlList) ? controlList : [];
+        const controlMatch = matchList.find(
           (c) => Number(c.id_control_stock) === Number(controlId)
         );
         if (!controlMatch) {


### PR DESCRIPTION
## Summary
- update product search hook to fetch control stock separately
- fetch control stock in ProductSearchCard after products load

## Testing
- `npm test -- -w 1`

------
https://chatgpt.com/codex/tasks/task_e_6860f5c0b2e48331825a39c55a75b4a0