### PR TITLE
Improve product stock UX

### DIFF
--- a/src/components/ProductSearch/ProductSearchCard.jsx
+++ b/src/components/ProductSearch/ProductSearchCard.jsx
@@ -15,6 +15,7 @@ import { CartContext } from "../../contexts/CartContext";
 import { ClientContext } from "../../contexts/ClientContext";
 import { OverlayPanel } from "primereact/overlaypanel";
 import { Toast } from "primereact/toast";
+import ControlStockModal from "../modals/controlStock/ControlStockModal";
 
 const ProductSearchCard = ({
   onAddProduct,
@@ -30,6 +31,8 @@ const ProductSearchCard = ({
   const [selectedProduct, setSelectedProduct] = useState(null);
   const [trackingList, setTrackingList] = useState([]);
   const overlayPanelRef = useRef(null);
+  const [controlStockModalOpen, setControlStockModalOpen] = useState(false);
+  const [controlStockQuery, setControlStockQuery] = useState("");
 
   const { configData } = useContext(ConfigContext);
   const { shopId, idProfile } = useContext(AuthContext);
@@ -172,6 +175,8 @@ const ProductSearchCard = ({
   const handleKeyDown = async (event) => {
     if (event.key !== "Enter") return;
     await handleSearch(searchTerm);
+    setSelectedProduct(null);
+    if (onClickProduct) onClickProduct(null);
     setSearchTerm("");
     setTimeout(() => {
       if (!disableAutoFocus && searchInputRef.current) {
@@ -184,6 +189,12 @@ const ProductSearchCard = ({
   const handleTrackingClick = (event, rowData) => {
     setTrackingList(rowData.controlStockList || []);
     overlayPanelRef.current.toggle(event);
+  };
+
+  const handleTrackingItemClick = (id) => {
+    setControlStockQuery(String(id));
+    setControlStockModalOpen(true);
+    overlayPanelRef.current.hide();
   };
 
   return (
@@ -426,7 +437,11 @@ const ProductSearchCard = ({
 
       <OverlayPanel ref={overlayPanelRef}>
         {trackingList.map((item, index) => (
-          <div key={index} className="flex items-center gap-2">
+          <div
+            key={index}
+            className="flex items-center gap-2 cursor-pointer"
+            onClick={() => handleTrackingItemClick(item.id_control_stock)}
+          >
             <span className="flex items-center">
               {item.id_control_stock}
               <i className="pi pi-link" style={{ marginLeft: "0.5rem" }}></i>
@@ -442,8 +457,13 @@ const ProductSearchCard = ({
           </div>
         ))}
       </OverlayPanel>
+      <ControlStockModal
+        isOpen={controlStockModalOpen}
+        onClose={() => setControlStockModalOpen(false)}
+        initialQuery={controlStockQuery}
+      />
     </div>
   );
 };
 
-export default ProductSearchCard;
+export default ProductSearchCard

--- a/src/components/Stock/StoreStockPanel.jsx
+++ b/src/components/Stock/StoreStockPanel.jsx
@@ -16,6 +16,7 @@ function StoreStockPanel({ product }) {
   const [trackingList, setTrackingList] = useState([]);
   const overlayPanelRef = useRef(null);
 
+
   useEffect(() => {
     apiFetch(`${API_BASE_URL}/shops`, { method: "GET" })
       .then((res) => {
@@ -37,6 +38,7 @@ function StoreStockPanel({ product }) {
   useEffect(() => {
     if (!product || !product.stocks) {
       setStocksByShop({});
+      setTrackingList([]);
       return;
     }
     const map = {};
@@ -55,6 +57,17 @@ function StoreStockPanel({ product }) {
     setTrackingList(details);
     overlayPanelRef.current.toggle(event);
   };
+
+  if (!product) {
+    return (
+      <div
+        className="h-full flex items-center justify-center p-3"
+        style={{ backgroundColor: "var(--surface-0)", color: "var(--text-color)" }}
+      >
+        <span>Seleccione un producto para ver stock</span>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/src/components/modals/controlStock/ControlStockModal.jsx
+++ b/src/components/modals/controlStock/ControlStockModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Dialog } from "primereact/dialog";
 import { InputText } from "primereact/inputtext";
 import { Button } from "primereact/button";
@@ -8,20 +8,32 @@ import { useApiFetch } from "../../../utils/useApiFetch";
 import getApiBaseUrl from "../../../utils/getApiBaseUrl";
 import { useShopsDictionary } from "../../../hooks/useShopsDictionary";
 
-const ControlStockModal = ({ isOpen, onClose, inlineMode = false }) => {
-  const [searchQuery, setSearchQuery] = useState("");
+const ControlStockModal = ({
+  isOpen,
+  onClose,
+  inlineMode = false,
+  initialQuery = "",
+}) => {
+  const [searchQuery, setSearchQuery] = useState(initialQuery);
   const [results, setResults] = useState(null);
   const [loading, setLoading] = useState(false);
   const apiFetch = useApiFetch();
   const API_BASE_URL = getApiBaseUrl();
   const shopsDict = useShopsDictionary();
 
-  const handleSearch = async () => {
+  useEffect(() => {
+    if (isOpen && initialQuery) {
+      setSearchQuery(initialQuery);
+      handleSearch(initialQuery);
+    }
+  }, [isOpen, initialQuery]);
+
+  const handleSearch = async (query) => {
     setLoading(true);
     try {
       const data = await apiFetch(
         `${API_BASE_URL}/get_controll_stock?id=${encodeURIComponent(
-          searchQuery
+          query ?? searchQuery
         )}`
       );
       // Si no hay resultados o el objeto está vacío, se limpia la data


### PR DESCRIPTION
## Summary
- clear selected product on new search to avoid old stock info
- show message in stock panel when no product is selected
- open ControlStockModal from tracking overlay
- support initial search query in ControlStockModal

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c01123a2c833182653f05a67afacb