### PR TITLE
Add ticket actions to control stock history

### DIFF
--- a/src/components/modals/controlStock/ControlStockModal.jsx
+++ b/src/components/modals/controlStock/ControlStockModal.jsx
@@ -10,6 +10,7 @@ import { useShopsDictionary } from "../../../hooks/useShopsDictionary";
 import { ConfigContext } from "../../../contexts/ConfigContext";
 import generateTicket from "../../../utils/ticket";
 import { useEmployeesDictionary } from "../../../hooks/useEmployeesDictionary";
+import MovementDetailModal from "../transfers/MovementDetailModal";
 
 const ControlStockModal = ({
   isOpen,
@@ -29,6 +30,8 @@ const ControlStockModal = ({
   const [printOptionModalVisible, setPrintOptionModalVisible] = useState(false);
   const [manualPdfDataUrl, setManualPdfDataUrl] = useState(null);
   const [orderDataForPrint, setOrderDataForPrint] = useState(null);
+  const [movementModalVisible, setMovementModalVisible] = useState(false);
+  const [movementData, setMovementData] = useState(null);
 
   useEffect(() => {
     if (isOpen && initialQuery) {
@@ -92,6 +95,17 @@ const ControlStockModal = ({
           }
         } else {
           console.error("Error al recuperar datos del ticket");
+        }
+      } else if (!isOrder && origin && origin.id_warehouse_movement) {
+        const movement = await apiFetch(
+          `${API_BASE_URL}/get_warehouse_movement?id_warehouse_movement=${origin.id_warehouse_movement}`,
+          { method: "GET" }
+        );
+        if (movement) {
+          setMovementData(movement);
+          setMovementModalVisible(true);
+        } else {
+          console.error("Error al obtener detalle del movimiento");
         }
       }
     } catch (err) {
@@ -282,6 +296,14 @@ const ControlStockModal = ({
         )}
       </div>
     </Dialog>
+    <MovementDetailModal
+      isOpen={movementModalVisible}
+      onClose={() => {
+        setMovementModalVisible(false);
+        setMovementData(null);
+      }}
+      movementData={movementData}
+    />
     <Dialog
       header="Error de impresión"
       visible={printOptionModalVisible}

--- a/src/components/modals/controlStock/ControlStockModal.jsx
+++ b/src/components/modals/controlStock/ControlStockModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { Dialog } from "primereact/dialog";
 import { InputText } from "primereact/inputtext";
 import { Button } from "primereact/button";
@@ -7,6 +7,9 @@ import { Column } from "primereact/column";
 import { useApiFetch } from "../../../utils/useApiFetch";
 import getApiBaseUrl from "../../../utils/getApiBaseUrl";
 import { useShopsDictionary } from "../../../hooks/useShopsDictionary";
+import { ConfigContext } from "../../../contexts/ConfigContext";
+import generateTicket from "../../../utils/ticket";
+import { useEmployeesDictionary } from "../../../hooks/useEmployeesDictionary";
 
 const ControlStockModal = ({
   isOpen,
@@ -20,6 +23,12 @@ const ControlStockModal = ({
   const apiFetch = useApiFetch();
   const API_BASE_URL = getApiBaseUrl();
   const shopsDict = useShopsDictionary();
+  const { configData } = useContext(ConfigContext);
+  const employeesDict = useEmployeesDictionary();
+
+  const [printOptionModalVisible, setPrintOptionModalVisible] = useState(false);
+  const [manualPdfDataUrl, setManualPdfDataUrl] = useState(null);
+  const [orderDataForPrint, setOrderDataForPrint] = useState(null);
 
   useEffect(() => {
     if (isOpen && initialQuery) {
@@ -49,7 +58,91 @@ const ControlStockModal = ({
     setLoading(false);
   };
 
+  const handleTransactionClick = async (rowData) => {
+    const type = rowData.type ? rowData.type.toLowerCase() : "";
+    const isOrder = type === "venta" || type === "devolución";
+    try {
+      const origin = await apiFetch(`${API_BASE_URL}/get_transaction_origin`, {
+        method: "POST",
+        body: JSON.stringify({
+          id_transaction_detail: rowData.id_transaction_detail,
+          type: isOrder ? "order" : "movement",
+        }),
+      });
+      if (isOrder && origin && origin.id_order) {
+        const order = await apiFetch(`${API_BASE_URL}/get_order`, {
+          method: "POST",
+          body: JSON.stringify({ id_order: origin.id_order, origin: "mayret" }),
+        });
+        if (order && order.order_details) {
+          setOrderDataForPrint(order);
+          const response = await generateTicket(
+            "print",
+            order,
+            configData,
+            employeesDict
+          );
+          if (!response.success) {
+            if (response.manual) {
+              setManualPdfDataUrl(response.pdfDataUrl);
+              setPrintOptionModalVisible(true);
+            } else {
+              console.error("Error al imprimir ticket:", response.message);
+            }
+          }
+        } else {
+          console.error("Error al recuperar datos del ticket");
+        }
+      }
+    } catch (err) {
+      console.error("Error obteniendo origen de transacción:", err);
+    }
+  };
+
+  const handleManualPrint = () => {
+    if (manualPdfDataUrl) {
+      const printWindow = window.open("", "_blank");
+      if (printWindow) {
+        printWindow.document.write(
+          `<html><head><title>Vista Previa del PDF</title></head>
+           <body style="margin:0">
+             <iframe width="100%" height="100%" src="${manualPdfDataUrl}" frameborder="0"></iframe>
+           </body></html>`
+        );
+        printWindow.document.close();
+        printWindow.focus();
+        setPrintOptionModalVisible(false);
+      } else {
+        console.warn("No se pudo abrir la ventana de previsualización");
+      }
+    }
+  };
+
+  const handleRetryPrint = async () => {
+    if (orderDataForPrint) {
+      try {
+        const response = await generateTicket(
+          "print",
+          orderDataForPrint,
+          configData,
+          employeesDict
+        );
+        if (response.success) {
+          console.log("Reimpresión remota exitosa");
+          setPrintOptionModalVisible(false);
+        } else if (response.manual) {
+          setManualPdfDataUrl(response.pdfDataUrl);
+        } else {
+          console.error("Error al reintentar imprimir ticket:", response.message);
+        }
+      } catch (err) {
+        console.error("Error al reintentar impresión:", err);
+      }
+    }
+  };
+
   return (
+    <>
     <Dialog
       header="Seguimiento de productos"
       visible={isOpen}
@@ -153,8 +246,31 @@ const ControlStockModal = ({
                     <Column
                       field="id_transaction_detail"
                       header="ID Transacción"
-                      style={{ textAlign: "center" }}
+                      style={{ textAlign: "center", cursor: "pointer" }}
                       alignHeader="center"
+                      body={(rowData) => {
+                        const type = rowData.type ? rowData.type.toLowerCase() : "";
+                        const icons = [];
+                        if (type === "venta") {
+                          icons.push(<i key="print" className="pi pi-print mr-1" />);
+                        } else if (type === "devolución") {
+                          icons.push(<i key="print" className="pi pi-print mr-1" />);
+                          icons.push(<i key="undo" className="pi pi-undo mr-1" />);
+                        } else if (type === "entrada") {
+                          icons.push(<i key="in" className="pi pi-download mr-1" />);
+                        } else if (type === "salida") {
+                          icons.push(<i key="out" className="pi pi-upload mr-1" />);
+                        } else if (type === "traspaso") {
+                          icons.push(
+                            <i key="move" className="pi pi-arrow-right-arrow-left mr-1" />
+                          );
+                        }
+                        return (
+                          <span onClick={() => handleTransactionClick(rowData)}>
+                            {icons} {rowData.id_transaction_detail}
+                          </span>
+                        );
+                      }}
                     />
                   </DataTable>
                 ) : (
@@ -166,6 +282,33 @@ const ControlStockModal = ({
         )}
       </div>
     </Dialog>
+    <Dialog
+      header="Error de impresión"
+      visible={printOptionModalVisible}
+      onHide={() => setPrintOptionModalVisible(false)}
+      modal
+      draggable={false}
+      resizable={false}
+      style={{ marginBottom: "150px" }}
+    >
+      <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+        <span>
+          La impresión del ticket ha fallado. ¿Deseas imprimirlo manualmente o
+          reintentar?
+        </span>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            gap: "0.5rem",
+          }}
+        >
+          <Button label="Imprimir manual" onClick={handleManualPrint} />
+          <Button label="Reintentar" onClick={handleRetryPrint} />
+        </div>
+      </div>
+    </Dialog>
+    </>
   );
 };
 

--- a/src/components/modals/transfers/MovementDetailModal.jsx
+++ b/src/components/modals/transfers/MovementDetailModal.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Dialog } from "primereact/dialog";
+import TransferForm from "./TransferForm";
+
+const MovementDetailModal = ({ isOpen, onClose, movementData }) => {
+  if (!movementData) return null;
+  const type = movementData.type ? movementData.type.toLowerCase() : "";
+  const title =
+    type === "traspaso"
+      ? "Traspaso entre tiendas"
+      : type === "entrada"
+      ? "Entrada de mercadería"
+      : type === "salida"
+      ? "Salida de mercadería"
+      : "Movimiento";
+
+  return (
+    <Dialog
+      visible={isOpen}
+      onHide={onClose}
+      header={title}
+      draggable={false}
+      resizable={false}
+      modal
+      style={{ maxWidth: "70vw", maxHeight: "85vh", width: "65vw", height: "80vh" }}
+    >
+      <TransferForm movementData={movementData} type={movementData.type} hideFooter={true} />
+    </Dialog>
+  );
+};
+
+export default MovementDetailModal;


### PR DESCRIPTION
## Summary
- show icons for transaction type in ControlStockModal
- allow clicking ID Transacción to fetch origin and print order ticket if applicable
- handle manual print fallback when remote print fails

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686d1878baf48331b6124d18bda5104d