### PR TITLE
Aplicar formato largo a fechas

### DIFF
--- a/src/components/modals/cashRegister/ListCashRegisterModal.jsx
+++ b/src/components/modals/cashRegister/ListCashRegisterModal.jsx
@@ -11,7 +11,7 @@ import { useEmployeesDictionary } from "../../../hooks/useEmployeesDictionary";
 import { ConfigContext } from "../../../contexts/ConfigContext";
 import { AuthContext } from "../../../contexts/AuthContext";
 import { generateClosureTicket } from "../../../utils/ticket";
-import { formatLongDate } from "../../../utils/dateUtils";
+import { formatLongDate, formatFullDateTime } from "../../../utils/dateUtils";
 
 const ListCashRegisterModal = ({ isOpen, onClose, inlineMode = false }) => {
   const [sessions, setSessions] = useState([]);
@@ -253,8 +253,9 @@ const ListCashRegisterModal = ({ isOpen, onClose, inlineMode = false }) => {
             <Column
               field="date_add"
               header="Fecha Apertura"
-              style={{ textAlign: "center", width: "130px" }}
+              style={{ textAlign: "center", width: "200px" }}
               alignHeader="center"
+              body={(rowData) => formatFullDateTime(rowData.date_add)}
             ></Column>
             <Column
               field="id_employee_open"
@@ -268,8 +269,11 @@ const ListCashRegisterModal = ({ isOpen, onClose, inlineMode = false }) => {
             <Column
               field="date_close"
               header="Fecha Cierre"
-              style={{ textAlign: "center", width: "130px" }}
+              style={{ textAlign: "center", width: "200px" }}
               alignHeader="center"
+              body={(rowData) =>
+                rowData.date_close ? formatFullDateTime(rowData.date_close) : ""
+              }
             ></Column>
             <Column
               field="id_employee_close"

--- a/src/components/modals/controlStock/ControlStockModal.jsx
+++ b/src/components/modals/controlStock/ControlStockModal.jsx
@@ -10,6 +10,7 @@ import { useShopsDictionary } from "../../../hooks/useShopsDictionary";
 import { ConfigContext } from "../../../contexts/ConfigContext";
 import generateTicket from "../../../utils/ticket";
 import { useEmployeesDictionary } from "../../../hooks/useEmployeesDictionary";
+import { formatFullDateTime } from "../../../utils/dateUtils";
 import MovementDetailModal from "../transfers/MovementDetailModal";
 
 const ControlStockModal = ({
@@ -217,7 +218,7 @@ const ControlStockModal = ({
                     </div>
                     <div className="p-col">
                       <strong>Fecha creación seguimiento:</strong>{" "}
-                      {results.date_add}
+                      {formatFullDateTime(results.date_add)}
                     </div>
                     <div className="p-col">
                       <strong>Activo:</strong> {results.active ? "Sí" : "No"}
@@ -238,6 +239,7 @@ const ControlStockModal = ({
                         header="Fecha movimiento"
                         style={{ textAlign: "center" }}
                         alignHeader="center"
+                        body={(rowData) => formatFullDateTime(rowData.date)}
                       />
                       <Column
                         body={(rowData) => (

--- a/src/components/modals/online/OnlineOrdersModal.jsx
+++ b/src/components/modals/online/OnlineOrdersModal.jsx
@@ -14,7 +14,7 @@ import { Toast } from "primereact/toast";
 import { TabView, TabPanel } from "primereact/tabview";
 import getApiBaseUrl from "../../../utils/getApiBaseUrl";
 import useProductSearchOptimized from "../../../hooks/useProductSearchOptimized";
-import { formatDate } from "../../../utils/dateUtils";
+import { formatFullDateTimeNoSeconds } from "../../../utils/dateUtils";
 import { AuthContext } from "../../../contexts/AuthContext";
 import ActionResultDialog from "../../common/ActionResultDialog";
 import generateTicket from "../../../utils/ticket";
@@ -552,7 +552,7 @@ const OnlineOrdersModal = ({ isOpen, onClose }) => {
                 />
                 <Column
                   header="Fecha"
-                  body={(row) => formatDate(row.date_add)}
+                  body={(row) => formatFullDateTimeNoSeconds(row.date_add)}
                   style={{
                     width: "auto",
                     textAlign: "center",
@@ -695,7 +695,7 @@ const OnlineOrdersModal = ({ isOpen, onClose }) => {
                 />
                 <Column
                   header="Fecha"
-                  body={(row) => formatDate(row.date_add)}
+                  body={(row) => formatFullDateTimeNoSeconds(row.date_add)}
                   style={{
                     width: "230px",
                     textAlign: "center",
@@ -1043,7 +1043,7 @@ const OnlineOrdersModal = ({ isOpen, onClose }) => {
                 <strong>Estado:</strong> {selectedOrder.current_state_name}
               </div>
               <div className="p-col-6">
-                <strong>Fecha:</strong> {formatDate(selectedOrder.date_add)}
+                <strong>Fecha:</strong> {formatFullDateTimeNoSeconds(selectedOrder.date_add)}
               </div>
               <div className="p-col-12">
                 <strong>Origen:</strong> {selectedOrder.origin}

--- a/src/components/modals/transfers/TransferForm.jsx
+++ b/src/components/modals/transfers/TransferForm.jsx
@@ -28,7 +28,7 @@ import JsBarcode from "jsbarcode";
 import useProductSearchOptimized from "../../../hooks/useProductSearchOptimized";
 import { ClientContext } from "../../../contexts/ClientContext";
 import { generatePriceLabels } from "../../../utils/generatePriceLabels";
-import { formatShortDate } from "../../../utils/dateUtils";
+import { formatFullDateTime } from "../../../utils/dateUtils";
 
 const TransferForm = forwardRef(
   ({ type, onSave, movementData, onFooterChange }, ref) => {
@@ -163,12 +163,11 @@ const TransferForm = forwardRef(
 
     useEffect(() => {
       if (isNewMovement) {
-        setCreateDate(new Date().toISOString().split("T")[0]);
+        setCreateDate(new Date());
         setEmployeeId(employeeId);
       } else {
         if (movementData?.date_add) {
-          const onlyDate = movementData.date_add.split(" ")[0];
-          setCreateDate(onlyDate);
+          setCreateDate(movementData.date_add);
         }
         setMovementStatus(movementData?.status || "en creacion");
         setEmployeeId(movementData?.employee);
@@ -1302,7 +1301,7 @@ const TransferForm = forwardRef(
             <div className="p-inputgroup flex-1">
               <FloatLabel>
                 <label>Fecha creación</label>
-                <InputText value={formatShortDate(createDate)} readOnly />
+                <InputText value={formatFullDateTime(createDate)} readOnly />
               </FloatLabel>
             </div>
             <div className="p-inputgroup flex-1">

--- a/src/components/modals/transfers/TransfersModal.jsx
+++ b/src/components/modals/transfers/TransfersModal.jsx
@@ -22,7 +22,7 @@ import { useEmployeesDictionary } from "../../../hooks/useEmployeesDictionary";
 import { ProgressSpinner } from "primereact/progressspinner";
 import { ConfirmDialog, confirmDialog } from "primereact/confirmdialog";
 import { Toast } from "primereact/toast";
-import { formatDate } from "../../../utils/dateUtils";
+import { formatFullDateTime } from "../../../utils/dateUtils";
 
 // Definir filtros iniciales para global y para cada columna
 const initialFilters = {
@@ -154,10 +154,10 @@ const TransfersModal = ({ isOpen, onClose }) => {
               );
         const formattedData = filteredData.map((mov) => ({
           ...mov,
-          date_add: formatDate(mov.date_add),
-          date_excute: formatDate(mov.date_excute),
-          date_modified: formatDate(mov.date_modified),
-          date_recived: formatDate(mov.date_recived),
+          date_add: formatFullDateTime(mov.date_add),
+          date_excute: formatFullDateTime(mov.date_excute),
+          date_modified: formatFullDateTime(mov.date_modified),
+          date_recived: formatFullDateTime(mov.date_recived),
         }));
         setUnfilteredMovements(formattedData);
         setMovements(formattedData);

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -10,6 +10,43 @@ export function formatDate(dateString) {
   return `${dd}-${mm}-${yyyy} ${hh}:${min}`;
 }
 
+export function formatFullDateTime(dateStr) {
+  if (!dateStr) return "";
+  const cleanStr =
+    typeof dateStr === "string" && dateStr.includes(" ")
+      ? dateStr.replace(" ", "T")
+      : dateStr;
+  const d = new Date(cleanStr);
+  if (isNaN(d)) return dateStr;
+  const weekday = d.toLocaleDateString("es-ES", { weekday: "long" });
+  const day = d.toLocaleDateString("es-ES", { day: "2-digit" });
+  const month = d.toLocaleDateString("es-ES", { month: "long" });
+  const year = d.toLocaleDateString("es-ES", { year: "numeric" });
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  const ss = String(d.getSeconds()).padStart(2, "0");
+  const capitalizedWeekday = weekday.charAt(0).toUpperCase() + weekday.slice(1);
+  return `${capitalizedWeekday} ${day} de ${month} de ${year} ${hh}:${mm}:${ss}`;
+}
+
+export function formatFullDateTimeNoSeconds(dateStr) {
+  if (!dateStr) return "";
+  const cleanStr =
+    typeof dateStr === "string" && dateStr.includes(" ")
+      ? dateStr.replace(" ", "T")
+      : dateStr;
+  const d = new Date(cleanStr);
+  if (isNaN(d)) return dateStr;
+  const weekday = d.toLocaleDateString("es-ES", { weekday: "long" });
+  const day = d.toLocaleDateString("es-ES", { day: "2-digit" });
+  const month = d.toLocaleDateString("es-ES", { month: "long" });
+  const year = d.toLocaleDateString("es-ES", { year: "numeric" });
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  const capitalizedWeekday = weekday.charAt(0).toUpperCase() + weekday.slice(1);
+  return `${capitalizedWeekday} ${day} de ${month} de ${year} ${hh}:${mm}`;
+}
+
 export function formatLongDate(dateStr) {
   if (!dateStr) return "";
   const d = new Date(dateStr);


### PR DESCRIPTION
## Summary
- add full date time formatting utilities
- show fechas completas en ControlStockModal
- usar formato completo en TransfersModal y TransferForm
- mostrar fechas completas en ListCashRegisterModal
- ajustar fecha en OnlineOrdersModal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e367f94408331b4e0e2a5e0025e38