### PR TITLE
Restrict access to ControlStockModal

### DIFF
--- a/src/components/ProductSearch/ProductSearchCard.jsx
+++ b/src/components/ProductSearch/ProductSearchCard.jsx
@@ -187,11 +187,13 @@ const ProductSearchCard = ({
 
   // Función para abrir el overlay panel con los seguimientos
   const handleTrackingClick = (event, rowData) => {
+    if (idProfile !== 1) return;
     setTrackingList(rowData.controlStockList || []);
     overlayPanelRef.current.toggle(event);
   };
 
   const handleTrackingItemClick = (id) => {
+    if (idProfile !== 1) return;
     setControlStockQuery(String(id));
     setControlStockModalOpen(true);
     overlayPanelRef.current.hide();
@@ -331,8 +333,13 @@ const ProductSearchCard = ({
                   {Number(rowData.trackingCount) > 0 && (
                     <i
                       className="pi pi-link"
-                      style={{ cursor: "pointer" }}
-                      onClick={(e) => handleTrackingClick(e, rowData)}
+                      style={{
+                        cursor: idProfile === 1 ? "pointer" : "default",
+                        opacity: idProfile === 1 ? 1 : 0.5,
+                      }}
+                      onClick={(e) =>
+                        idProfile === 1 && handleTrackingClick(e, rowData)
+                      }
                     ></i>
                   )}
                 </>
@@ -439,8 +446,14 @@ const ProductSearchCard = ({
         {trackingList.map((item, index) => (
           <div
             key={index}
-            className="flex items-center gap-2 cursor-pointer"
-            onClick={() => handleTrackingItemClick(item.id_control_stock)}
+            className="flex items-center gap-2"
+            style={{
+              cursor: idProfile === 1 ? "pointer" : "default",
+              opacity: idProfile === 1 ? 1 : 0.5,
+            }}
+            onClick={() =>
+              idProfile === 1 && handleTrackingItemClick(item.id_control_stock)
+            }
           >
             <span className="flex items-center">
               {item.id_control_stock}

--- a/src/components/ProductSearch/ProductSearchCard.jsx
+++ b/src/components/ProductSearch/ProductSearchCard.jsx
@@ -96,21 +96,13 @@ const ProductSearchCard = ({
     document.querySelector('[role="dialog"]') !== null;
 
   const handleContainerClick = () => {
-    if (
-      !disableAutoFocus &&
-      !isAnyModalOpen() &&
-      searchInputRef.current
-    ) {
+    if (!disableAutoFocus && !isAnyModalOpen() && searchInputRef.current) {
       searchInputRef.current.focus();
     }
   };
 
   const handleInputBlur = () => {
-    if (
-      !disableAutoFocus &&
-      !isAnyModalOpen() &&
-      searchInputRef.current
-    ) {
+    if (!disableAutoFocus && !isAnyModalOpen() && searchInputRef.current) {
       searchInputRef.current.focus();
     }
   };
@@ -187,7 +179,6 @@ const ProductSearchCard = ({
 
   // Función para abrir el overlay panel con los seguimientos
   const handleTrackingClick = (event, rowData) => {
-    if (idProfile !== 1) return;
     setTrackingList(rowData.controlStockList || []);
     overlayPanelRef.current.toggle(event);
   };
@@ -334,12 +325,10 @@ const ProductSearchCard = ({
                     <i
                       className="pi pi-link"
                       style={{
-                        cursor: idProfile === 1 ? "pointer" : "default",
-                        opacity: idProfile === 1 ? 1 : 0.5,
+                        cursor: "pointer",
+                        opacity: 1,
                       }}
-                      onClick={(e) =>
-                        idProfile === 1 && handleTrackingClick(e, rowData)
-                      }
+                      onClick={(e) => handleTrackingClick(e, rowData)}
                     ></i>
                   )}
                 </>
@@ -449,7 +438,7 @@ const ProductSearchCard = ({
             className="flex items-center gap-2"
             style={{
               cursor: idProfile === 1 ? "pointer" : "default",
-              opacity: idProfile === 1 ? 1 : 0.5,
+              opacity: 1,
             }}
             onClick={() =>
               idProfile === 1 && handleTrackingItemClick(item.id_control_stock)
@@ -479,4 +468,4 @@ const ProductSearchCard = ({
   );
 };
 
-export default ProductSearchCard
+export default ProductSearchCard;

--- a/src/components/Stock/StoreStockPanel.jsx
+++ b/src/components/Stock/StoreStockPanel.jsx
@@ -5,6 +5,7 @@ import { useApiFetch } from "../../utils/useApiFetch";
 import { AuthContext } from "../../contexts/AuthContext";
 import getApiBaseUrl from "../../utils/getApiBaseUrl";
 import { OverlayPanel } from "primereact/overlaypanel";
+import ControlStockModal from "../modals/controlStock/ControlStockModal";
 
 function StoreStockPanel({ product }) {
   const apiFetch = useApiFetch();
@@ -15,6 +16,8 @@ function StoreStockPanel({ product }) {
 
   const [trackingList, setTrackingList] = useState([]);
   const overlayPanelRef = useRef(null);
+  const [controlStockModalOpen, setControlStockModalOpen] = useState(false);
+  const [controlStockQuery, setControlStockQuery] = useState("");
 
 
   useEffect(() => {
@@ -50,12 +53,20 @@ function StoreStockPanel({ product }) {
 
   // Función para abrir el overlay panel en cada tienda
   const handleStoreTrackingClick = (event, shopId) => {
+    if (idProfile !== 1) return;
     const stock = product.stocks.find(
       (s) => Number(s.id_shop) === Number(shopId)
     );
     const details = stock && stock.control_stock ? stock.control_stock : [];
     setTrackingList(details);
     overlayPanelRef.current.toggle(event);
+  };
+
+  const handleTrackingItemClick = (id) => {
+    if (idProfile !== 1) return;
+    setControlStockQuery(String(id));
+    setControlStockModalOpen(true);
+    overlayPanelRef.current.hide();
   };
 
   if (!product) {
@@ -100,8 +111,13 @@ function StoreStockPanel({ product }) {
               {hasTracking && (
                 <i
                   className="pi pi-link"
-                  style={{ cursor: "pointer" }}
-                  onClick={(e) => handleStoreTrackingClick(e, shop.id_shop)}
+                  style={{
+                    cursor: idProfile === 1 ? "pointer" : "default",
+                    opacity: idProfile === 1 ? 1 : 0.5,
+                  }}
+                  onClick={(e) =>
+                    idProfile === 1 && handleStoreTrackingClick(e, shop.id_shop)
+                  }
                 ></i>
               )}
             </div>
@@ -109,23 +125,38 @@ function StoreStockPanel({ product }) {
         })}
       </div>
       <OverlayPanel ref={overlayPanelRef}>
-              {trackingList.map((item, index) => (
-                <div key={index} className="flex items-center gap-2">
-                  <span className="flex items-center">
-                    {item.id_control_stock}
-                    <i className="pi pi-link" style={{ marginLeft: "0.5rem" }}></i>
-                  </span>
-                  <i
-                    className={`pi ${
-                      item.active_control_stock ? "pi-check" : "pi-times"
-                    }`}
-                    style={{
-                      color: item.active_control_stock ? "green" : "red",
-                    }}
-                  ></i>
-                </div>
-              ))}
-            </OverlayPanel>
+        {trackingList.map((item, index) => (
+          <div
+            key={index}
+            className="flex items-center gap-2"
+            style={{
+              cursor: idProfile === 1 ? "pointer" : "default",
+              opacity: idProfile === 1 ? 1 : 0.5,
+            }}
+            onClick={() =>
+              idProfile === 1 && handleTrackingItemClick(item.id_control_stock)
+            }
+          >
+            <span className="flex items-center">
+              {item.id_control_stock}
+              <i className="pi pi-link" style={{ marginLeft: "0.5rem" }}></i>
+            </span>
+            <i
+              className={`pi ${
+                item.active_control_stock ? "pi-check" : "pi-times"
+              }`}
+              style={{
+                color: item.active_control_stock ? "green" : "red",
+              }}
+            ></i>
+          </div>
+        ))}
+      </OverlayPanel>
+      <ControlStockModal
+        isOpen={controlStockModalOpen}
+        onClose={() => setControlStockModalOpen(false)}
+        initialQuery={controlStockQuery}
+      />
     </div>
   );
 }

--- a/src/components/Stock/StoreStockPanel.jsx
+++ b/src/components/Stock/StoreStockPanel.jsx
@@ -19,7 +19,6 @@ function StoreStockPanel({ product }) {
   const [controlStockModalOpen, setControlStockModalOpen] = useState(false);
   const [controlStockQuery, setControlStockQuery] = useState("");
 
-
   useEffect(() => {
     apiFetch(`${API_BASE_URL}/shops`, { method: "GET" })
       .then((res) => {
@@ -28,9 +27,7 @@ function StoreStockPanel({ product }) {
           const filtered = data.filter((s) => s.id_shop !== 1);
           setShops(filtered);
         } else {
-          const filtered = data.filter(
-            (s) => s.id_shop === shopId
-          );
+          const filtered = data.filter((s) => s.id_shop === shopId);
           setShops(filtered);
         }
       })
@@ -53,7 +50,6 @@ function StoreStockPanel({ product }) {
 
   // Función para abrir el overlay panel en cada tienda
   const handleStoreTrackingClick = (event, shopId) => {
-    if (idProfile !== 1) return;
     const stock = product.stocks.find(
       (s) => Number(s.id_shop) === Number(shopId)
     );
@@ -73,7 +69,10 @@ function StoreStockPanel({ product }) {
     return (
       <div
         className="h-full flex items-center justify-center p-3"
-        style={{ backgroundColor: "var(--surface-0)", color: "var(--text-color)" }}
+        style={{
+          backgroundColor: "var(--surface-0)",
+          color: "var(--text-color)",
+        }}
       >
         <span>Seleccione un producto para ver stock</span>
       </div>
@@ -112,12 +111,10 @@ function StoreStockPanel({ product }) {
                 <i
                   className="pi pi-link"
                   style={{
-                    cursor: idProfile === 1 ? "pointer" : "default",
-                    opacity: idProfile === 1 ? 1 : 0.5,
+                    cursor: "pointer",
+                    opacity: 1,
                   }}
-                  onClick={(e) =>
-                    idProfile === 1 && handleStoreTrackingClick(e, shop.id_shop)
-                  }
+                  onClick={(e) => handleStoreTrackingClick(e, shop.id_shop)}
                 ></i>
               )}
             </div>
@@ -131,7 +128,7 @@ function StoreStockPanel({ product }) {
             className="flex items-center gap-2"
             style={{
               cursor: idProfile === 1 ? "pointer" : "default",
-              opacity: idProfile === 1 ? 1 : 0.5,
+              opacity: 1,
             }}
             onClick={() =>
               idProfile === 1 && handleTrackingItemClick(item.id_control_stock)


### PR DESCRIPTION
## Summary
- allow only admin users to open ControlStockModal
- share modal behavior between product search and store stock panels

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_686eae4deca4833194b1233175a142d2