### PR TITLE
Add email stock alert modal

### DIFF
--- a/src/components/Navbar/NavbarCard.jsx
+++ b/src/components/Navbar/NavbarCard.jsx
@@ -23,6 +23,7 @@ import InventoryModal from "../modals/inventory/InventoryModal";
 import ListCashRegisterModal from "../modals/cashRegister/ListCashRegisterModal";
 import ControlStockModal from "../modals/controlStock/ControlStockModal";
 import DiscountsListModal from "../modals/discount/DiscountsListModal";
+import StockFixedModal from "../modals/stockFixed/StockFixedModal";
 import useToggle from "../../hooks/useToggle";
 
 const NavbarCard = () => {
@@ -54,6 +55,7 @@ const NavbarCard = () => {
   const inventoryModal = useToggle();
   const controlStockModal = useToggle();
   const discountsListModal = useToggle();
+  const stockFixedModal = useToggle();
 
   const closeAllModals = () => {
     transfersModal.close();
@@ -64,6 +66,7 @@ const NavbarCard = () => {
     pinDialog.close();
     listCashRegisterModal.close();
     controlStockModal.close();
+    stockFixedModal.close();
     inventoryModal.close();
     discountsListModal.close();
     onlineOrdersModal.close();
@@ -110,6 +113,11 @@ const NavbarCard = () => {
   const openDiscountsList = () => {
     closeAllModals();
     discountsListModal.open();
+  };
+
+  const openStockFixed = () => {
+    closeAllModals();
+    stockFixedModal.open();
   };
 
   const openControlStock = () => {
@@ -169,6 +177,11 @@ const NavbarCard = () => {
                 label: "Seguimiento",
                 icon: "pi pi-link",
                 command: openControlStock,
+              },
+              {
+                label: "Aviso Stock Correo",
+                icon: "pi pi-envelope",
+                command: openStockFixed,
               },
             ],
           },
@@ -441,6 +454,13 @@ const NavbarCard = () => {
         <ControlStockModal
           isOpen={controlStockModal.isOpen}
           onClose={controlStockModal.close}
+        />
+      )}
+
+      {stockFixedModal.isOpen && (
+        <StockFixedModal
+          isOpen={stockFixedModal.isOpen}
+          onClose={stockFixedModal.close}
         />
       )}
 

--- a/src/components/modals/stockFixed/StockFixedAddModal.jsx
+++ b/src/components/modals/stockFixed/StockFixedAddModal.jsx
@@ -1,0 +1,175 @@
+import React, { useState } from "react";
+import { Dialog } from "primereact/dialog";
+import { InputText } from "primereact/inputtext";
+import { Button } from "primereact/button";
+import { DataTable } from "primereact/datatable";
+import { Column } from "primereact/column";
+import { InputNumber } from "primereact/inputnumber";
+import { useApiFetch } from "../../../utils/useApiFetch";
+import getApiBaseUrl from "../../../utils/getApiBaseUrl";
+
+const StockFixedAddModal = ({ isOpen, onClose, onSuccess }) => {
+  const apiFetch = useApiFetch();
+  const API_BASE_URL = getApiBaseUrl();
+  const [search, setSearch] = useState("");
+  const [results, setResults] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [selection, setSelection] = useState([]);
+  const [quantities, setQuantities] = useState({});
+
+  const handleSearch = async () => {
+    if (!search.trim()) return;
+    setLoading(true);
+    try {
+      const payload = { search_term: search };
+      const data = await apiFetch(`${API_BASE_URL}/product_search`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      setResults(Array.isArray(data) ? data : []);
+    } catch (err) {
+      console.error("Error searching products:", err);
+      setResults([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const updateQuantity = (ean, shop, value) => {
+    setQuantities((prev) => ({
+      ...prev,
+      [ean]: { ...prev[ean], [shop]: value },
+    }));
+  };
+
+  const handleAdd = async () => {
+    const payload = selection.map((row) => {
+      const ean = row.ean13_combination || row.ean13_combination_0 || row.ean13;
+      const q = quantities[ean] || {};
+      return {
+        ean13: ean,
+        quantity_shop_1: q.quantity_shop_1 || 0,
+        quantity_shop_2: q.quantity_shop_2 || 0,
+        quantity_shop_3: q.quantity_shop_3 || 0,
+      };
+    });
+    if (payload.length === 0) return;
+    try {
+      await apiFetch(`${API_BASE_URL}/stock_fixed_add`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (onSuccess) onSuccess();
+    } catch (err) {
+      console.error("Error adding stock fixed:", err);
+    }
+  };
+
+  const productNameTemplate = (row) => {
+    const comb = row.combination_name && row.combination_name !== ""
+      ? row.combination_name
+      : row.product_name;
+    return `${row.reference_combination} - ${comb}`;
+  };
+
+  const stockForShop = (row, shopId) => {
+    if (!row.stocks) return 0;
+    const s = row.stocks.find((stk) => Number(stk.id_shop) === Number(shopId));
+    return s ? s.quantity : 0;
+  };
+
+  const quantityBody = (ean, shopKey) => {
+    const value = quantities[ean]?.[shopKey] || 0;
+    const disabled = !selection.some((sel) => {
+      const e = sel.ean13_combination || sel.ean13_combination_0 || sel.ean13;
+      return e === ean;
+    });
+    return (
+      <InputNumber
+        value={value}
+        disabled={disabled}
+        onChange={(e) => updateQuantity(ean, shopKey, e.value)}
+        showButtons
+        buttonLayout="horizontal"
+        decrementButtonClassName="p-button-secondary"
+        incrementButtonClassName="p-button-secondary"
+        incrementButtonIcon="pi pi-plus"
+        decrementButtonIcon="pi pi-minus"
+        min={0}
+      />
+    );
+  };
+
+  return (
+    <Dialog
+      header="Añadir productos"
+      visible={isOpen}
+      onHide={onClose}
+      modal
+      draggable={false}
+      resizable={false}
+      style={{ width: "70vw", maxWidth: "900px" }}
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button label="Cancelar" className="p-button-text" onClick={onClose} />
+          <Button label="Añadir" onClick={handleAdd} disabled={selection.length === 0} />
+        </div>
+      }
+    >
+      <div className="flex items-end gap-2 mb-3">
+        <InputText
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") handleSearch(); }}
+          placeholder="Buscar producto"
+          className="w-full"
+        />
+        <Button label="Buscar" icon="pi pi-search" onClick={handleSearch} />
+      </div>
+      <DataTable
+        value={results}
+        loading={loading}
+        selection={selection}
+        onSelectionChange={(e) => setSelection(e.value)}
+        selectionMode="checkbox"
+        dataKey="id_product_attribute"
+        responsiveLayout="scroll"
+        paginator
+        rows={5}
+        emptyMessage="Sin resultados"
+      >
+        <Column selectionMode="multiple" headerStyle={{ width: "3em" }}></Column>
+        <Column header="Nombre" body={productNameTemplate} />
+        <Column header="EAN13" body={(row) => row.ean13_combination || row.ean13_combination_0 || row.ean13 || ""} />
+        <Column header="Stock tienda 1" body={(row) => stockForShop(row, 1)} />
+        <Column header="Stock tienda 2" body={(row) => stockForShop(row, 2)} />
+        <Column header="Stock tienda 3" body={(row) => stockForShop(row, 3)} />
+        <Column
+          header="Cantidad tienda 1"
+          body={(row) => {
+            const ean = row.ean13_combination || row.ean13_combination_0 || row.ean13;
+            return quantityBody(ean, "quantity_shop_1");
+          }}
+        />
+        <Column
+          header="Cantidad tienda 2"
+          body={(row) => {
+            const ean = row.ean13_combination || row.ean13_combination_0 || row.ean13;
+            return quantityBody(ean, "quantity_shop_2");
+          }}
+        />
+        <Column
+          header="Cantidad tienda 3"
+          body={(row) => {
+            const ean = row.ean13_combination || row.ean13_combination_0 || row.ean13;
+            return quantityBody(ean, "quantity_shop_3");
+          }}
+        />
+      </DataTable>
+    </Dialog>
+  );
+};
+
+export default StockFixedAddModal;

--- a/src/components/modals/stockFixed/StockFixedModal.jsx
+++ b/src/components/modals/stockFixed/StockFixedModal.jsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from "react";
+import { Dialog } from "primereact/dialog";
+import { DataTable } from "primereact/datatable";
+import { Column } from "primereact/column";
+import { Button } from "primereact/button";
+import { useApiFetch } from "../../../utils/useApiFetch";
+import getApiBaseUrl from "../../../utils/getApiBaseUrl";
+import StockFixedAddModal from "./StockFixedAddModal";
+
+const StockFixedModal = ({ isOpen, onClose }) => {
+  const apiFetch = useApiFetch();
+  const API_BASE_URL = getApiBaseUrl();
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [addModalOpen, setAddModalOpen] = useState(false);
+
+  const fetchList = async () => {
+    setLoading(true);
+    try {
+      const res = await apiFetch(`${API_BASE_URL}/stock_fixed_list`, { method: "GET" });
+      setData(Array.isArray(res) ? res : []);
+    } catch (err) {
+      console.error("Error fetching stock fixed list:", err);
+      setData([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchList();
+    }
+  }, [isOpen]);
+
+  const handleSuccessAdd = () => {
+    setAddModalOpen(false);
+    fetchList();
+  };
+
+  return (
+    <>
+      <Dialog
+        header="Aviso Stock Correo"
+        visible={isOpen}
+        onHide={onClose}
+        modal
+        draggable={false}
+        resizable={false}
+        style={{ width: "60vw", maxWidth: "800px" }}
+      >
+        <div className="mb-3">
+          <Button label="Añadir producto" icon="pi pi-plus" onClick={() => setAddModalOpen(true)} />
+        </div>
+        <DataTable
+          value={data}
+          loading={loading}
+          paginator
+          rows={10}
+          responsiveLayout="scroll"
+          emptyMessage="No hay registros"
+        >
+          <Column field="id_stock" header="ID" style={{ width: "80px" }} />
+          <Column field="ean13" header="EAN13" style={{ width: "150px" }} />
+          <Column field="quantity_shop_1" header="Tienda 1" style={{ width: "100px" }} />
+          <Column field="quantity_shop_2" header="Tienda 2" style={{ width: "100px" }} />
+          <Column field="quantity_shop_3" header="Tienda 3" style={{ width: "100px" }} />
+        </DataTable>
+      </Dialog>
+      {addModalOpen && (
+        <StockFixedAddModal
+          isOpen={addModalOpen}
+          onClose={() => setAddModalOpen(false)}
+          onSuccess={handleSuccessAdd}
+        />
+      )}
+    </>
+  );
+};
+
+export default StockFixedModal;


### PR DESCRIPTION
## Summary
- add StockFixedModal and StockFixedAddModal for managing stock alert list
- register the new modal in Navbar with menu option "Aviso Stock Correo"

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6876b23df9a88331915db20f7b5bb977