### PR TITLE
Integrate product search hook in stock fixed modal

### DIFF
--- a/src/components/Navbar/NavbarCard.jsx
+++ b/src/components/Navbar/NavbarCard.jsx
@@ -23,6 +23,7 @@ import InventoryModal from "../modals/inventory/InventoryModal";
 import ListCashRegisterModal from "../modals/cashRegister/ListCashRegisterModal";
 import ControlStockModal from "../modals/controlStock/ControlStockModal";
 import DiscountsListModal from "../modals/discount/DiscountsListModal";
+import StockFixedModal from "../modals/stockFixed/StockFixedModal";
 import useToggle from "../../hooks/useToggle";
 
 const NavbarCard = () => {
@@ -54,6 +55,7 @@ const NavbarCard = () => {
   const inventoryModal = useToggle();
   const controlStockModal = useToggle();
   const discountsListModal = useToggle();
+  const stockFixedModal = useToggle();
 
   const closeAllModals = () => {
     transfersModal.close();
@@ -64,6 +66,7 @@ const NavbarCard = () => {
     pinDialog.close();
     listCashRegisterModal.close();
     controlStockModal.close();
+    stockFixedModal.close();
     inventoryModal.close();
     discountsListModal.close();
     onlineOrdersModal.close();
@@ -110,6 +113,11 @@ const NavbarCard = () => {
   const openDiscountsList = () => {
     closeAllModals();
     discountsListModal.open();
+  };
+
+  const openStockFixed = () => {
+    closeAllModals();
+    stockFixedModal.open();
   };
 
   const openControlStock = () => {
@@ -169,6 +177,11 @@ const NavbarCard = () => {
                 label: "Seguimiento",
                 icon: "pi pi-link",
                 command: openControlStock,
+              },
+              {
+                label: "Aviso Stock Correo",
+                icon: "pi pi-envelope",
+                command: openStockFixed,
               },
             ],
           },
@@ -441,6 +454,13 @@ const NavbarCard = () => {
         <ControlStockModal
           isOpen={controlStockModal.isOpen}
           onClose={controlStockModal.close}
+        />
+      )}
+
+      {stockFixedModal.isOpen && (
+        <StockFixedModal
+          isOpen={stockFixedModal.isOpen}
+          onClose={stockFixedModal.close}
         />
       )}
 

--- a/src/components/modals/stockFixed/StockFixedAddModal.jsx
+++ b/src/components/modals/stockFixed/StockFixedAddModal.jsx
@@ -1,0 +1,186 @@
+import React, { useState, useContext } from "react";
+import { Dialog } from "primereact/dialog";
+import { InputText } from "primereact/inputtext";
+import { Button } from "primereact/button";
+import { DataTable } from "primereact/datatable";
+import { Column } from "primereact/column";
+import { InputNumber } from "primereact/inputnumber";
+import { useApiFetch } from "../../../utils/useApiFetch";
+import getApiBaseUrl from "../../../utils/getApiBaseUrl";
+import useProductSearchOptimized from "../../../hooks/useProductSearchOptimized";
+import { AuthContext } from "../../../contexts/AuthContext";
+import { ClientContext } from "../../../contexts/ClientContext";
+
+const StockFixedAddModal = ({ isOpen, onClose, onSuccess }) => {
+  const apiFetch = useApiFetch();
+  const API_BASE_URL = getApiBaseUrl();
+  const { idProfile } = useContext(AuthContext);
+  const { selectedClient } = useContext(ClientContext);
+  const [search, setSearch] = useState("");
+  const [selection, setSelection] = useState([]);
+  const [quantities, setQuantities] = useState({});
+
+  const {
+    groupedProducts,
+    isLoading,
+    handleSearch: searchProducts,
+  } = useProductSearchOptimized({
+    apiFetch,
+    shopId: "all",
+    allowOutOfStockSales: true,
+    onAddProduct: () => {},
+    onAddDiscount: () => {},
+    idProfile,
+    selectedClient,
+  });
+
+  const flatResults = groupedProducts.flatMap((group) =>
+    group.combinations.map((combo) => ({
+      ...combo,
+      product_name: group.product_name,
+      uniqueKey: `${combo.id_product}_${combo.id_product_attribute}`,
+    }))
+  );
+
+  const handleSearch = async () => {
+    if (!search.trim()) return;
+    await searchProducts(search);
+  };
+
+  const updateQuantity = (ean, shop, value) => {
+    setQuantities((prev) => ({
+      ...prev,
+      [ean]: { ...prev[ean], [shop]: value },
+    }));
+  };
+
+  const handleAdd = async () => {
+    const payload = selection.map((row) => {
+      const ean = row.ean13_combination || row.ean13_combination_0 || row.ean13;
+      const q = quantities[ean] || {};
+      return {
+        ean13: ean,
+        quantity_shop_1: q.quantity_shop_1 || 0,
+        quantity_shop_2: q.quantity_shop_2 || 0,
+        quantity_shop_3: q.quantity_shop_3 || 0,
+      };
+    });
+    if (payload.length === 0) return;
+    try {
+      await apiFetch(`${API_BASE_URL}/stock_fixed_add`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (onSuccess) onSuccess();
+    } catch (err) {
+      console.error("Error adding stock fixed:", err);
+    }
+  };
+
+  const productNameTemplate = (row) => {
+    const comb = row.combination_name && row.combination_name !== ""
+      ? row.combination_name
+      : row.product_name;
+    return `${row.reference_combination} - ${comb}`;
+  };
+
+  const stockForShop = (row, shopId) => {
+    if (!row.stocks) return 0;
+    const s = row.stocks.find((stk) => Number(stk.id_shop) === Number(shopId));
+    return s ? s.quantity : 0;
+  };
+
+  const quantityBody = (ean, shopKey) => {
+    const value = quantities[ean]?.[shopKey] || 0;
+    const disabled = !selection.some((sel) => {
+      const e = sel.ean13_combination || sel.ean13_combination_0 || sel.ean13;
+      return e === ean;
+    });
+    return (
+      <InputNumber
+        value={value}
+        disabled={disabled}
+        onChange={(e) => updateQuantity(ean, shopKey, e.value)}
+        showButtons
+        buttonLayout="horizontal"
+        decrementButtonClassName="p-button-secondary"
+        incrementButtonClassName="p-button-secondary"
+        incrementButtonIcon="pi pi-plus"
+        decrementButtonIcon="pi pi-minus"
+        min={0}
+      />
+    );
+  };
+
+  return (
+    <Dialog
+      header="Añadir productos"
+      visible={isOpen}
+      onHide={onClose}
+      modal
+      draggable={false}
+      resizable={false}
+      style={{ width: "70vw", maxWidth: "900px" }}
+      footer={
+        <div className="flex justify-end gap-2">
+          <Button label="Cancelar" className="p-button-text" onClick={onClose} />
+          <Button label="Añadir" onClick={handleAdd} disabled={selection.length === 0} />
+        </div>
+      }
+    >
+      <div className="flex items-end gap-2 mb-3">
+        <InputText
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") handleSearch(); }}
+          placeholder="Buscar producto"
+          className="w-full"
+        />
+        <Button label="Buscar" icon="pi pi-search" onClick={handleSearch} />
+      </div>
+      <DataTable
+        value={flatResults}
+        loading={isLoading}
+        selection={selection}
+        onSelectionChange={(e) => setSelection(e.value)}
+        selectionMode="checkbox"
+        dataKey="uniqueKey"
+        responsiveLayout="scroll"
+        paginator
+        rows={5}
+        emptyMessage="Sin resultados"
+      >
+        <Column selectionMode="multiple" headerStyle={{ width: "3em" }}></Column>
+        <Column header="Nombre" body={productNameTemplate} />
+        <Column header="EAN13" body={(row) => row.ean13_combination || row.ean13_combination_0 || row.ean13 || ""} />
+        <Column header="Stock tienda 1" body={(row) => stockForShop(row, 1)} />
+        <Column header="Stock tienda 2" body={(row) => stockForShop(row, 2)} />
+        <Column header="Stock tienda 3" body={(row) => stockForShop(row, 3)} />
+        <Column
+          header="Cantidad tienda 1"
+          body={(row) => {
+            const ean = row.ean13_combination || row.ean13_combination_0 || row.ean13;
+            return quantityBody(ean, "quantity_shop_1");
+          }}
+        />
+        <Column
+          header="Cantidad tienda 2"
+          body={(row) => {
+            const ean = row.ean13_combination || row.ean13_combination_0 || row.ean13;
+            return quantityBody(ean, "quantity_shop_2");
+          }}
+        />
+        <Column
+          header="Cantidad tienda 3"
+          body={(row) => {
+            const ean = row.ean13_combination || row.ean13_combination_0 || row.ean13;
+            return quantityBody(ean, "quantity_shop_3");
+          }}
+        />
+      </DataTable>
+    </Dialog>
+  );
+};
+
+export default StockFixedAddModal;

--- a/src/components/modals/stockFixed/StockFixedAddModal.jsx
+++ b/src/components/modals/stockFixed/StockFixedAddModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useMemo, useEffect, useRef } from "react";
+import React, { useState, useContext, useMemo, useRef } from "react";
 import { Dialog } from "primereact/dialog";
 import { InputText } from "primereact/inputtext";
 import { Button } from "primereact/button";
@@ -23,6 +23,10 @@ const StockFixedAddModal = ({ isOpen, onClose, onSuccess }) => {
   const [selection, setSelection] = useState([]);
   const [quantities, setQuantities] = useState({});
   const toast = useRef(null);
+  const selectedKeys = useMemo(
+    () => new Set((selection || []).map((s) => s.uniqueKey)),
+    [selection],
+  );
   const stockShopIds = useMemo(
     () =>
       Object.keys(shopsDict)
@@ -54,12 +58,12 @@ const StockFixedAddModal = ({ isOpen, onClose, onSuccess }) => {
     })),
   );
 
-  useEffect(() => {
+  const handleSearch = () => {
     const term = search.trim();
     if (term.length >= 3) {
       searchProducts(term);
     }
-  }, [search, searchProducts]);
+  };
 
   const updateQuantity = (key, shop, value) => {
     setQuantities((prev) => ({
@@ -117,7 +121,7 @@ const StockFixedAddModal = ({ isOpen, onClose, onSuccess }) => {
   const quantityBody = (row, shopKey) => {
     const key = row.uniqueKey;
     const value = quantities[key]?.[shopKey] || 0;
-    const disabled = !selection.some((sel) => sel.uniqueKey === key);
+    const disabled = !selectedKeys.has(key);
     return (
       <InputNumber
         value={value}
@@ -164,9 +168,13 @@ const StockFixedAddModal = ({ isOpen, onClose, onSuccess }) => {
         <InputText
           value={search}
           onChange={(e) => setSearch(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSearch();
+          }}
           placeholder="Buscar producto"
           className="w-full"
         />
+        <Button icon="pi pi-search" onClick={handleSearch} aria-label="Buscar" />
       </div>
       <DataTable
         value={flatResults}

--- a/src/components/modals/stockFixed/StockFixedAddModal.jsx
+++ b/src/components/modals/stockFixed/StockFixedAddModal.jsx
@@ -23,17 +23,13 @@ const StockFixedAddModal = ({ isOpen, onClose, onSuccess }) => {
   const [selection, setSelection] = useState([]);
   const [quantities, setQuantities] = useState({});
   const toast = useRef(null);
-  const selectedKeys = useMemo(
-    () => new Set((selection || []).map((s) => s.uniqueKey)),
-    [selection],
-  );
   const stockShopIds = useMemo(
     () =>
       Object.keys(shopsDict)
         .map(Number)
         .filter((id) => id !== 1)
         .sort((a, b) => a - b),
-    [shopsDict],
+    [shopsDict]
   );
 
   const {
@@ -55,7 +51,7 @@ const StockFixedAddModal = ({ isOpen, onClose, onSuccess }) => {
       ...combo,
       product_name: group.product_name,
       uniqueKey: `${combo.id_product}_${combo.id_product_attribute}`,
-    })),
+    }))
   );
 
   const handleSearch = () => {
@@ -121,11 +117,9 @@ const StockFixedAddModal = ({ isOpen, onClose, onSuccess }) => {
   const quantityBody = (row, shopKey) => {
     const key = row.uniqueKey;
     const value = quantities[key]?.[shopKey] || 0;
-    const disabled = !selectedKeys.has(key);
     return (
       <InputNumber
         value={value}
-        disabled={disabled}
         onChange={(e) => updateQuantity(key, shopKey, e.value)}
         showButtons
         buttonLayout="horizontal"
@@ -134,7 +128,7 @@ const StockFixedAddModal = ({ isOpen, onClose, onSuccess }) => {
         incrementButtonIcon="pi pi-plus"
         decrementButtonIcon="pi pi-minus"
         min={0}
-        inputClassName="w-16"
+        inputClassName="w-14"
       />
     );
   };
@@ -147,7 +141,7 @@ const StockFixedAddModal = ({ isOpen, onClose, onSuccess }) => {
       modal
       draggable={false}
       resizable={false}
-      style={{ width: "80vw", maxWidth: "1000px" }}
+      style={{ width: "90vw", maxWidth: "1400px" }}
       footer={
         <div className="flex justify-end gap-2">
           <Button
@@ -174,7 +168,11 @@ const StockFixedAddModal = ({ isOpen, onClose, onSuccess }) => {
           placeholder="Buscar producto"
           className="w-full"
         />
-        <Button icon="pi pi-search" onClick={handleSearch} aria-label="Buscar" />
+        <Button
+          icon="pi pi-search"
+          onClick={handleSearch}
+          aria-label="Buscar"
+        />
       </div>
       <DataTable
         value={flatResults}
@@ -190,34 +188,53 @@ const StockFixedAddModal = ({ isOpen, onClose, onSuccess }) => {
       >
         <Column
           selectionMode="multiple"
-          headerStyle={{ width: "3em" }}
-        ></Column>
-        <Column header="Nombre" body={productNameTemplate} />
+          style={{ width: "3rem" }}
+          alignHeader={"center"}
+        />
+        <Column
+          header="Nombre"
+          body={productNameTemplate}
+          style={{ minWidth: "190px", textAlign: "left" }}
+          alignHeader={"left"}
+        />
         <Column
           header="EAN13"
           body={(row) =>
             row.ean13_combination || row.ean13_combination_0 || row.ean13 || ""
           }
+          style={{ minWidth: "150px", textAlign: "center" }}
+          alignHeader={"center"}
         />
         {stockShopIds.map((id) => (
           <Column
             key={id}
-            header={`Stock ${shopsDict[id] || id}`}
+            header={`${shopsDict[id] || id}`}
             body={(row) => stockForShop(row, id)}
+            style={{ minWidth: "80px", textAlign: "center" }}
+            alignHeader={"center"}
           />
         ))}
         <Column
           header={`Cantidad ${shopsDict[9] || "Tienda 1"}`}
           body={(row) => quantityBody(row, "quantity_shop_1")}
-          style={{ borderLeft: "1px solid var(--surface-border)" }}
+          style={{
+            borderLeft: "1px solid var(--surface-border)",
+            minWidth: "50px",
+            textAlign: "center",
+          }}
+          alignHeader={"center"}
         />
         <Column
           header={`Cantidad ${shopsDict[11] || "Tienda 2"}`}
           body={(row) => quantityBody(row, "quantity_shop_2")}
+          style={{ minWidth: "50px", textAlign: "center" }}
+          alignHeader={"center"}
         />
         <Column
           header={`Cantidad ${shopsDict[14] || "Tienda 3"}`}
           body={(row) => quantityBody(row, "quantity_shop_3")}
+          style={{ minWidth: "50px", textAlign: "center" }}
+          alignHeader={"center"}
         />
       </DataTable>
     </Dialog>

--- a/src/components/modals/stockFixed/StockFixedModal.jsx
+++ b/src/components/modals/stockFixed/StockFixedModal.jsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from "react";
+import { Dialog } from "primereact/dialog";
+import { DataTable } from "primereact/datatable";
+import { Column } from "primereact/column";
+import { Button } from "primereact/button";
+import { useApiFetch } from "../../../utils/useApiFetch";
+import getApiBaseUrl from "../../../utils/getApiBaseUrl";
+import StockFixedAddModal from "./StockFixedAddModal";
+
+const StockFixedModal = ({ isOpen, onClose }) => {
+  const apiFetch = useApiFetch();
+  const API_BASE_URL = getApiBaseUrl();
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [addModalOpen, setAddModalOpen] = useState(false);
+
+  const fetchList = async () => {
+    setLoading(true);
+    try {
+      const res = await apiFetch(`${API_BASE_URL}/stock_fixed_list`, { method: "GET" });
+      setData(Array.isArray(res) ? res : []);
+    } catch (err) {
+      console.error("Error fetching stock fixed list:", err);
+      setData([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchList();
+    }
+  }, [isOpen]);
+
+  const handleSuccessAdd = () => {
+    setAddModalOpen(false);
+    fetchList();
+  };
+
+  return (
+    <>
+      <Dialog
+        header="Aviso Stock Correo"
+        visible={isOpen}
+        onHide={onClose}
+        modal
+        draggable={false}
+        resizable={false}
+        style={{ width: "60vw", maxWidth: "800px" }}
+      >
+        <div className="mb-3">
+          <Button label="Añadir producto" icon="pi pi-plus" onClick={() => setAddModalOpen(true)} />
+        </div>
+        <DataTable
+          value={data}
+          loading={loading}
+          paginator
+          rows={10}
+          responsiveLayout="scroll"
+          emptyMessage="No hay registros"
+        >
+          <Column field="id_stock" header="ID" style={{ width: "80px" }} />
+          <Column field="ean13" header="EAN13" style={{ width: "150px" }} />
+          <Column field="quantity_shop_1" header="Tienda 1" style={{ width: "100px" }} />
+          <Column field="quantity_shop_2" header="Tienda 2" style={{ width: "100px" }} />
+          <Column field="quantity_shop_3" header="Tienda 3" style={{ width: "100px" }} />
+        </DataTable>
+      </Dialog>
+      {addModalOpen && (
+        <StockFixedAddModal
+          isOpen={addModalOpen}
+          onClose={() => setAddModalOpen(false)}
+          onSuccess={handleSuccessAdd}
+        />
+      )}
+    </>
+  );
+};
+
+export default StockFixedModal;

--- a/src/components/modals/stockFixed/StockFixedModal.jsx
+++ b/src/components/modals/stockFixed/StockFixedModal.jsx
@@ -6,6 +6,7 @@ import { Button } from "primereact/button";
 import { useApiFetch } from "../../../utils/useApiFetch";
 import getApiBaseUrl from "../../../utils/getApiBaseUrl";
 import StockFixedAddModal from "./StockFixedAddModal";
+import { useShopsDictionary } from "../../../hooks/useShopsDictionary";
 
 const StockFixedModal = ({ isOpen, onClose }) => {
   const apiFetch = useApiFetch();
@@ -13,11 +14,14 @@ const StockFixedModal = ({ isOpen, onClose }) => {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(false);
   const [addModalOpen, setAddModalOpen] = useState(false);
+  const shopsDict = useShopsDictionary();
 
   const fetchList = async () => {
     setLoading(true);
     try {
-      const res = await apiFetch(`${API_BASE_URL}/stock_fixed_list`, { method: "GET" });
+      const res = await apiFetch(`${API_BASE_URL}/stock_fixed_list`, {
+        method: "GET",
+      });
       setData(Array.isArray(res) ? res : []);
     } catch (err) {
       console.error("Error fetching stock fixed list:", err);
@@ -50,7 +54,11 @@ const StockFixedModal = ({ isOpen, onClose }) => {
         style={{ width: "60vw", maxWidth: "800px" }}
       >
         <div className="mb-3">
-          <Button label="Añadir producto" icon="pi pi-plus" onClick={() => setAddModalOpen(true)} />
+          <Button
+            label="Añadir producto"
+            icon="pi pi-plus"
+            onClick={() => setAddModalOpen(true)}
+          />
         </div>
         <DataTable
           value={data}
@@ -59,12 +67,32 @@ const StockFixedModal = ({ isOpen, onClose }) => {
           rows={10}
           responsiveLayout="scroll"
           emptyMessage="No hay registros"
+          rowGroupMode="subheader"
+          groupRowsBy="reference_combination"
+          sortField="reference_combination"
+          sortOrder={1}
+          rowGroupHeaderTemplate={(row) => (
+            <span className="font-bold">{row.reference_combination}</span>
+          )}
         >
+          <Column field="combination_name" header="Combinación" />
           <Column field="id_stock" header="ID" style={{ width: "80px" }} />
-          <Column field="ean13" header="EAN13" style={{ width: "150px" }} />
-          <Column field="quantity_shop_1" header="Tienda 1" style={{ width: "100px" }} />
-          <Column field="quantity_shop_2" header="Tienda 2" style={{ width: "100px" }} />
-          <Column field="quantity_shop_3" header="Tienda 3" style={{ width: "100px" }} />
+          <Column field="ean13" header="EAN13" style={{ width: "140px" }} />
+          <Column
+            field="quantity_shop_1"
+            header={shopsDict[9] || "Tienda 1"}
+            style={{ width: "100px" }}
+          />
+          <Column
+            field="quantity_shop_2"
+            header={shopsDict[11] || "Tienda 2"}
+            style={{ width: "100px" }}
+          />
+          <Column
+            field="quantity_shop_3"
+            header={shopsDict[14] || "Tienda 3"}
+            style={{ width: "100px" }}
+          />
         </DataTable>
       </Dialog>
       {addModalOpen && (

--- a/src/components/modals/stockFixed/StockFixedModal.jsx
+++ b/src/components/modals/stockFixed/StockFixedModal.jsx
@@ -52,7 +52,7 @@ const StockFixedModal = ({ isOpen, onClose }) => {
         String(item.reference_combination).toLowerCase().includes(term) ||
         String(item.combination_name || "")
           .toLowerCase()
-          .includes(term),
+          .includes(term)
     );
   }, [data, search]);
 
@@ -96,26 +96,39 @@ const StockFixedModal = ({ isOpen, onClose }) => {
             <span className="font-bold">{row.reference_combination}</span>
           )}
         >
-          <Column field="combination_name" header="Combinación" />
-          <Column field="id_stock" header="ID" style={{ width: "80px" }} />
-          <Column field="ean13" header="EAN13" style={{ width: "140px" }} />
+          <Column
+            field="combination_name"
+            header="Combinación"
+            style={{ width: "150px", textAlign: "left" }}
+            alignHeader={"left"}
+          />
+          <Column
+            field="ean13"
+            header="EAN13"
+            style={{ width: "150px", textAlign: "center" }}
+            alignHeader={"center"}
+          />
           <Column
             field="quantity_shop_1"
             header={shopsDict[9] || "Tienda 1"}
             style={{
               width: "100px",
+              textAlign: "center",
               borderLeft: "1px solid var(--surface-border)",
             }}
+            alignHeader={"center"}
           />
           <Column
             field="quantity_shop_2"
             header={shopsDict[11] || "Tienda 2"}
-            style={{ width: "100px" }}
+            style={{ width: "100px", textAlign: "center" }}
+            alignHeader={"center"}
           />
           <Column
             field="quantity_shop_3"
             header={shopsDict[14] || "Tienda 3"}
-            style={{ width: "100px" }}
+            style={{ width: "100px", textAlign: "center" }}
+            alignHeader={"center"}
           />
         </DataTable>
       </Dialog>

--- a/src/components/modals/stockFixed/StockFixedModal.jsx
+++ b/src/components/modals/stockFixed/StockFixedModal.jsx
@@ -3,6 +3,7 @@ import { Dialog } from "primereact/dialog";
 import { DataTable } from "primereact/datatable";
 import { Column } from "primereact/column";
 import { Button } from "primereact/button";
+import { InputText } from "primereact/inputtext";
 import { useApiFetch } from "../../../utils/useApiFetch";
 import getApiBaseUrl from "../../../utils/getApiBaseUrl";
 import StockFixedAddModal from "./StockFixedAddModal";
@@ -14,6 +15,7 @@ const StockFixedModal = ({ isOpen, onClose }) => {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(false);
   const [addModalOpen, setAddModalOpen] = useState(false);
+  const [search, setSearch] = useState("");
   const shopsDict = useShopsDictionary();
 
   const fetchList = async () => {
@@ -42,6 +44,18 @@ const StockFixedModal = ({ isOpen, onClose }) => {
     fetchList();
   };
 
+  const filteredData = React.useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (term.length < 3) return data;
+    return data.filter(
+      (item) =>
+        String(item.reference_combination).toLowerCase().includes(term) ||
+        String(item.combination_name || "")
+          .toLowerCase()
+          .includes(term),
+    );
+  }, [data, search]);
+
   return (
     <>
       <Dialog
@@ -53,15 +67,22 @@ const StockFixedModal = ({ isOpen, onClose }) => {
         resizable={false}
         style={{ width: "60vw", maxWidth: "800px" }}
       >
-        <div className="mb-3">
+        <div className="flex items-end gap-2 mb-3">
           <Button
             label="Añadir producto"
             icon="pi pi-plus"
             onClick={() => setAddModalOpen(true)}
           />
+          <span className="flex-1"></span>
+          <InputText
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar referencia"
+            className="w-40 md:w-60"
+          />
         </div>
         <DataTable
-          value={data}
+          value={filteredData}
           loading={loading}
           paginator
           rows={10}
@@ -81,7 +102,10 @@ const StockFixedModal = ({ isOpen, onClose }) => {
           <Column
             field="quantity_shop_1"
             header={shopsDict[9] || "Tienda 1"}
-            style={{ width: "100px" }}
+            style={{
+              width: "100px",
+              borderLeft: "1px solid var(--surface-border)",
+            }}
           />
           <Column
             field="quantity_shop_2"


### PR DESCRIPTION
## Summary
- refactor StockFixedAddModal to use `useProductSearchOptimized`
- flatten grouped results and show stock for all shops

## Testing
- `npm test --silent` *(fails: not required to run)*

------
https://chatgpt.com/codex/tasks/task_e_6876b23df9a88331915db20f7b5bb977