### PR TITLE
Fix product selection dialog

### DIFF
--- a/src/components/modals/transfers/ProductSearchCardForTransfer.jsx
+++ b/src/components/modals/transfers/ProductSearchCardForTransfer.jsx
@@ -172,6 +172,7 @@ const ProductSearchCardForTransfer = ({
         map[key] = {
           id_product: prod.id_product,
           id_product_attribute: prod.id_product_attribute,
+          uniqueKey: key,
           product_name: prod.combination_name
             ? `${prod.reference_combination} - ${prod.combination_name}`
             : prod.product_name,

--- a/src/components/modals/transfers/ProductSelectionDialog.jsx
+++ b/src/components/modals/transfers/ProductSelectionDialog.jsx
@@ -2,7 +2,6 @@ import React, { useState, useRef, useEffect } from "react";
 import { Dialog } from "primereact/dialog";
 import { DataTable } from "primereact/datatable";
 import { Column } from "primereact/column";
-import { Checkbox } from "primereact/checkbox";
 import { Button } from "primereact/button";
 import getApiBaseUrl from "../../../utils/getApiBaseUrl";
 import { useApiFetch } from "../../../utils/useApiFetch";
@@ -45,33 +44,6 @@ const ProductSelectionDialog = ({
       setSelectedBarcodeItems([]);
     }
   }, [visible]);
-
-  const toggleSelection = (product) => {
-    setSelectedItems((prev) => {
-      const exists = prev.find(
-        (p) =>
-          p.id_product === product.id_product &&
-          p.id_product_attribute === product.id_product_attribute
-      );
-      if (exists) {
-        return prev.filter(
-          (p) =>
-            !(
-              p.id_product === product.id_product &&
-              p.id_product_attribute === product.id_product_attribute
-            )
-        );
-      }
-      return [...prev, product];
-    });
-  };
-
-  const isSelected = (product) =>
-    !!selectedItems.find(
-      (p) =>
-        p.id_product === product.id_product &&
-        p.id_product_attribute === product.id_product_attribute
-    );
 
   // Nuevas funciones para manejar la selección en la columna Cod. Barras
   const handleBarcodeClick = (product) => {
@@ -175,19 +147,6 @@ const ProductSelectionDialog = ({
     );
   };
 
-  // Función para renderizar la columna de selección (Checkbox) modificada para permitir selección múltiple en todos los registros
-  const selectionBodyTemplate = (rowData) => {
-    return (
-      <Checkbox
-        checked={isSelected(rowData)}
-        onChange={(e) => {
-          e.originalEvent.stopPropagation();
-          toggleSelection(rowData);
-        }}
-      />
-    );
-  };
-
   // Se modifica la función para renderizar el código de barras, haciéndola clickable
   const barcodeBodyTemplate = (rowData) => {
     return (
@@ -231,17 +190,18 @@ const ProductSelectionDialog = ({
         <div className="overflow-auto" style={{ maxHeight: "65vh" }}>
           <DataTable
             value={products}
+            selection={selectedItems}
+            onSelectionChange={(e) => setSelectedItems(e.value)}
             responsiveLayout="scroll"
             emptyMessage="No hay productos para mostrar."
             style={{
               backgroundColor: "var(--surface-0)",
               color: "var(--text-color)",
             }}
-            dataKey="uniqueKey"
-            onRowClick={(e) => toggleSelection(e.data)}
+            // Eliminamos onRowClick para evitar conflictos
           >
             <Column
-              body={selectionBodyTemplate}
+              selectionMode="multiple"
               style={{ textAlign: "center", width: "80px" }}
             />
             <Column header="Producto" field="product_name" />

--- a/src/components/modals/transfers/ProductSelectionDialog.jsx
+++ b/src/components/modals/transfers/ProductSelectionDialog.jsx
@@ -184,7 +184,10 @@ const ProductSelectionDialog = ({
     return (
       <Checkbox
         checked={isSelected(rowData)}
-        onChange={() => handleCheckboxChange(rowData)}
+        onChange={(e) => {
+          e.originalEvent.stopPropagation();
+          handleCheckboxChange(rowData);
+        }}
       />
     );
   };
@@ -238,6 +241,7 @@ const ProductSelectionDialog = ({
               backgroundColor: "var(--surface-0)",
               color: "var(--text-color)",
             }}
+            onRowClick={(e) => handleCheckboxChange(e.data)}
           >
             <Column
               body={selectionBodyTemplate}
@@ -249,11 +253,17 @@ const ProductSelectionDialog = ({
             {showOriginStock && (
               <Column
                 header={`Stock ${originShopName}`}
-                body={(rowData) => (
-                  <>
-                    <div>{rowData.stockOrigin ?? 0}</div>
-                    {rowData.originControlStock &&
-                      rowData.originControlStock.length > 0 && (
+                body={(rowData) => {
+                  const activeCount = rowData.originControlStock
+                    ? rowData.originControlStock.filter(
+                        (cs) => cs.active_control_stock
+                      ).length
+                    : 0;
+                  return (
+                    <>
+                      {rowData.stockOrigin ?? 0}
+                      {activeCount > 0 ? ` | ${activeCount} ` : ""}
+                      {activeCount > 0 && (
                         <Button
                           icon="pi pi-link"
                           className="p-button-text p-button-sm"
@@ -265,18 +275,25 @@ const ProductSelectionDialog = ({
                           }
                         />
                       )}
-                  </>
-                )}
+                    </>
+                  );
+                }}
               />
             )}
             {showDestinationStock && (
               <Column
                 header={`Stock ${destinationShopName}`}
-                body={(rowData) => (
-                  <>
-                    <div>{rowData.stockDestination ?? 0}</div>
-                    {rowData.destinationControlStock &&
-                      rowData.destinationControlStock.length > 0 && (
+                body={(rowData) => {
+                  const activeCount = rowData.destinationControlStock
+                    ? rowData.destinationControlStock.filter(
+                        (cs) => cs.active_control_stock
+                      ).length
+                    : 0;
+                  return (
+                    <>
+                      {rowData.stockDestination ?? 0}
+                      {activeCount > 0 ? ` | ${activeCount} ` : ""}
+                      {activeCount > 0 && (
                         <Button
                           icon="pi pi-link"
                           className="p-button-text p-button-sm"
@@ -288,8 +305,9 @@ const ProductSelectionDialog = ({
                           }
                         />
                       )}
-                  </>
-                )}
+                    </>
+                  );
+                }}
               />
             )}
           </DataTable>

--- a/src/components/modals/transfers/ProductSelectionDialog.jsx
+++ b/src/components/modals/transfers/ProductSelectionDialog.jsx
@@ -46,16 +46,14 @@ const ProductSelectionDialog = ({
     }
   }, [visible]);
 
-  // Al hacer check
-  const handleCheckboxChange = (product) => {
+  const toggleSelection = (product) => {
     setSelectedItems((prev) => {
-      const found = prev.find(
+      const exists = prev.find(
         (p) =>
           p.id_product === product.id_product &&
           p.id_product_attribute === product.id_product_attribute
       );
-      if (found) {
-        // Quitar
+      if (exists) {
         return prev.filter(
           (p) =>
             !(
@@ -63,10 +61,8 @@ const ProductSelectionDialog = ({
               p.id_product_attribute === product.id_product_attribute
             )
         );
-      } else {
-        // Agregar
-        return [...prev, product];
       }
+      return [...prev, product];
     });
   };
 
@@ -186,7 +182,7 @@ const ProductSelectionDialog = ({
         checked={isSelected(rowData)}
         onChange={(e) => {
           e.originalEvent.stopPropagation();
-          handleCheckboxChange(rowData);
+          toggleSelection(rowData);
         }}
       />
     );
@@ -241,7 +237,8 @@ const ProductSelectionDialog = ({
               backgroundColor: "var(--surface-0)",
               color: "var(--text-color)",
             }}
-            onRowClick={(e) => handleCheckboxChange(e.data)}
+            dataKey="uniqueKey"
+            onRowClick={(e) => toggleSelection(e.data)}
           >
             <Column
               body={selectionBodyTemplate}


### PR DESCRIPTION
## Summary
- allow selecting combinations in transfer modal by clicking the row
- show active tracking counts in stock columns like ProductSearchCard

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877a020fee483318ba101d27ee67a6d