### PR TITLE
Format euro values

### DIFF
--- a/src/components/modals/cashRegister/CloseCashRegisterForm.jsx
+++ b/src/components/modals/cashRegister/CloseCashRegisterForm.jsx
@@ -16,6 +16,7 @@ import { useEmployeesDictionary } from "../../../hooks/useEmployeesDictionary";
 import { ConfigContext } from "../../../contexts/ConfigContext";
 import { Dialog } from "primereact/dialog";
 import { generateSalesPdf } from "../../../utils/generateSalesPdf";
+import { formatCurrencyES } from "../../../utils/formatters";
 import "jspdf-autotable";
 import { formatLongDate } from "../../../utils/dateUtils";
 
@@ -27,9 +28,9 @@ const CloseCashRegisterForm = ({ onClose }) => {
   const [fetchedTotalCash, setFetchedTotalCash] = useState(0.0);
   const [fetchedTotalCard, setFetchedTotalCard] = useState(0.0);
   const [fetchedTotalBizum, setFetchedTotalBizum] = useState(0.0);
-  const [inputTotalCash, setInputTotalCash] = useState("");
-  const [inputTotalCard, setInputTotalCard] = useState("");
-  const [inputTotalBizum, setInputTotalBizum] = useState("");
+  const [inputTotalCash, setInputTotalCash] = useState(null);
+  const [inputTotalCard, setInputTotalCard] = useState(null);
+  const [inputTotalBizum, setInputTotalBizum] = useState(null);
   const [isCloseButtonDisabled, setIsCloseButtonDisabled] = useState(true);
   const [salesCount, setSalesCount] = useState(0);
   const [returnsCount, setReturnsCount] = useState(0);
@@ -94,10 +95,10 @@ const CloseCashRegisterForm = ({ onClose }) => {
   }, [license, apiFetch, API_BASE_URL]);
 
   useEffect(() => {
-    const inputCashNum = inputTotalCash === "" ? 0 : parseFloat(inputTotalCash);
-    const inputCardNum = inputTotalCard === "" ? 0 : parseFloat(inputTotalCard);
+    const inputCashNum = inputTotalCash == null ? 0 : parseFloat(inputTotalCash);
+    const inputCardNum = inputTotalCard == null ? 0 : parseFloat(inputTotalCard);
     const inputBizumNum =
-      inputTotalBizum === "" ? 0 : parseFloat(inputTotalBizum);
+      inputTotalBizum == null ? 0 : parseFloat(inputTotalBizum);
     const validInput =
       inputCashNum === fetchedTotalCash &&
       inputCardNum === fetchedTotalCard &&
@@ -413,7 +414,7 @@ const CloseCashRegisterForm = ({ onClose }) => {
                 <i className="pi pi-money-bill" />
               </span>
               <InputText
-                value={`${formatNumber(fetchedTotalCash.toFixed(2))} €`}
+                value={formatCurrencyES(fetchedTotalCash)}
                 disabled
                 className="text-right"
               />
@@ -432,7 +433,7 @@ const CloseCashRegisterForm = ({ onClose }) => {
                 <i className="pi pi-credit-card" />
               </span>
               <InputText
-                value={`${formatNumber(fetchedTotalCard.toFixed(2))} €`}
+                value={formatCurrencyES(fetchedTotalCard)}
                 disabled
                 className="text-right"
               />
@@ -451,7 +452,7 @@ const CloseCashRegisterForm = ({ onClose }) => {
                 <i className="pi pi-phone" />
               </span>
               <InputText
-                value={`${formatNumber(fetchedTotalBizum.toFixed(2))} €`}
+                value={formatCurrencyES(fetchedTotalBizum)}
                 disabled
                 className="text-right"
               />
@@ -510,7 +511,9 @@ const CloseCashRegisterForm = ({ onClose }) => {
             inputId="inputTotalCash"
             value={inputTotalCash}
             onValueChange={(e) => setInputTotalCash(e.value)}
-            mode="decimal"
+            mode="currency"
+            currency="EUR"
+            locale="es-ES"
             className="mt-1 block w-full border border-gray-300 rounded-md p-2"
           />
         </div>
@@ -525,7 +528,9 @@ const CloseCashRegisterForm = ({ onClose }) => {
             inputId="inputTotalCard"
             value={inputTotalCard}
             onValueChange={(e) => setInputTotalCard(e.value)}
-            mode="decimal"
+            mode="currency"
+            currency="EUR"
+            locale="es-ES"
             className="mt-1 block w-full border border-gray-300 rounded-md p-2"
           />
         </div>
@@ -540,7 +545,9 @@ const CloseCashRegisterForm = ({ onClose }) => {
             inputId="inputTotalBizum"
             value={inputTotalBizum}
             onValueChange={(e) => setInputTotalBizum(e.value)}
-            mode="decimal"
+            mode="currency"
+            currency="EUR"
+            locale="es-ES"
             className="mt-1 block w-full border border-gray-300 rounded-md p-2 mb-4"
           />
         </div>

--- a/src/components/modals/cashRegister/ListCashRegisterModal.jsx
+++ b/src/components/modals/cashRegister/ListCashRegisterModal.jsx
@@ -12,6 +12,7 @@ import { ConfigContext } from "../../../contexts/ConfigContext";
 import { AuthContext } from "../../../contexts/AuthContext";
 import { generateClosureTicket } from "../../../utils/ticket";
 import { formatLongDate, formatFullDateTime } from "../../../utils/dateUtils";
+import { formatCurrencyES } from "../../../utils/formatters";
 
 const ListCashRegisterModal = ({ isOpen, onClose, inlineMode = false }) => {
   const [sessions, setSessions] = useState([]);
@@ -289,24 +290,28 @@ const ListCashRegisterModal = ({ isOpen, onClose, inlineMode = false }) => {
               header="Caja Inicial"
               style={{ textAlign: "center", width: "100px" }}
               alignHeader="center"
+              body={(rowData) => formatCurrencyES(rowData.init_cash)}
             ></Column>
             <Column
               field="total_cash"
               header="Total Efectivo"
               style={{ textAlign: "center", width: "100px" }}
               alignHeader="center"
+              body={(rowData) => formatCurrencyES(rowData.total_cash)}
             ></Column>
             <Column
               field="total_card"
               header="Total Tarjeta"
               style={{ textAlign: "center", width: "100px" }}
               alignHeader="center"
+              body={(rowData) => formatCurrencyES(rowData.total_card)}
             ></Column>
             <Column
               field="total_bizum"
               header="Total Bizum"
               style={{ textAlign: "center", width: "100px" }}
               alignHeader="center"
+              body={(rowData) => formatCurrencyES(rowData.total_bizum)}
             ></Column>
             <Column
               field="active"

--- a/src/components/modals/discount/DiscountModal.jsx
+++ b/src/components/modals/discount/DiscountModal.jsx
@@ -198,6 +198,9 @@ const DiscountModal = ({
             showButtons={false}
             className="flex-grow"
             placeholder={discountType === "percentage" ? "0-100" : ">= 0"}
+            mode={discountType === "percentage" ? "decimal" : "currency"}
+            currency="EUR"
+            locale="es-ES"
           />
           <span className="ml-2">
             {discountType === "percentage" ? "%" : "€"}

--- a/src/components/modals/online/OnlineOrdersModal.jsx
+++ b/src/components/modals/online/OnlineOrdersModal.jsx
@@ -21,6 +21,7 @@ import generateTicket from "../../../utils/ticket";
 import { ConfigContext } from "../../../contexts/ConfigContext";
 import { useEmployeesDictionary } from "../../../hooks/useEmployeesDictionary";
 import { ClientContext } from "../../../contexts/ClientContext";
+import { formatCurrencyES } from "../../../utils/formatters";
 
 const OnlineOrdersModal = ({ isOpen, onClose }) => {
   const apiFetch = useApiFetch();
@@ -361,7 +362,7 @@ const OnlineOrdersModal = ({ isOpen, onClose }) => {
           <Column
             header="Total €"
             field="total_price_tax_incl"
-            body={(rowData) => Number(rowData.total_price_tax_incl).toFixed(2)}
+            body={(rowData) => formatCurrencyES(rowData.total_price_tax_incl)}
             bodyStyle={{ textAlign: "center", width: "10%" }}
           />
         </DataTable>
@@ -611,7 +612,7 @@ const OnlineOrdersModal = ({ isOpen, onClose }) => {
                 <Column
                   field="total_paid"
                   header="Total (€)"
-                  body={(data) => Number(data.total_paid)?.toFixed(2)}
+                  body={(data) => formatCurrencyES(data.total_paid)}
                   style={{
                     width: "auto",
                     textAlign: "center",
@@ -754,7 +755,7 @@ const OnlineOrdersModal = ({ isOpen, onClose }) => {
                 <Column
                   field="total_paid"
                   header="Total (€)"
-                  body={(data) => Number(data.total_paid)?.toFixed(2)}
+                  body={(data) => formatCurrencyES(data.total_paid)}
                   style={{
                     width: "100px",
                     textAlign: "center",
@@ -1036,8 +1037,7 @@ const OnlineOrdersModal = ({ isOpen, onClose }) => {
                 <strong>Pago:</strong> {selectedOrder.payment}
               </div>
               <div className="p-col-6">
-                <strong>Total (€):</strong>{" "}
-                {Number(selectedOrder.total_paid)?.toFixed(2)}
+                <strong>Total (€):</strong> {formatCurrencyES(selectedOrder.total_paid)}
               </div>
               <div className="p-col-6">
                 <strong>Estado:</strong> {selectedOrder.current_state_name}
@@ -1068,14 +1068,14 @@ const OnlineOrdersModal = ({ isOpen, onClose }) => {
               <Column
                 header="Precio"
                 field="product_price"
-                body={(rowData) => Number(rowData.product_price)?.toFixed(2)}
+                body={(rowData) => formatCurrencyES(rowData.product_price)}
                 bodyStyle={{ textAlign: "center" }}
               />
               <Column
                 header="Total €"
                 field="total_price_tax_incl"
                 body={(rowData) =>
-                  Number(rowData.total_price_tax_incl)?.toFixed(2)
+                  formatCurrencyES(rowData.total_price_tax_incl)
                 }
                 bodyStyle={{ textAlign: "center" }}
               />

--- a/src/components/modals/pos/OpenPosModal.jsx
+++ b/src/components/modals/pos/OpenPosModal.jsx
@@ -49,9 +49,10 @@ const OpenPosModal = ({ tokenParam, onSubmit, errorMessage }) => {
             value={initCash}
             onValueChange={(e) => setInitCash(e.value)}
             onKeyDown={handleKeyDown}
-            mode="decimal"
+            mode="currency"
+            currency="EUR"
+            locale="es-ES"
             min={0}
-            locale="es"
             className="w-full"
             inputClassName="w-full p-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
           />

--- a/src/components/modals/reprint/ReprintModal.jsx
+++ b/src/components/modals/reprint/ReprintModal.jsx
@@ -20,6 +20,7 @@ import getApiBaseUrl from "../../../utils/getApiBaseUrl";
 import { ConfigContext } from "../../../contexts/ConfigContext";
 import generateTicket from "../../../utils/ticket";
 import { useEmployeesDictionary } from "../../../hooks/useEmployeesDictionary";
+import { formatCurrencyES } from "../../../utils/formatters";
 
 const ReprintModal = ({ isOpen, onClose }) => {
   const apiFetch = useApiFetch();
@@ -192,15 +193,15 @@ const ReprintModal = ({ isOpen, onClose }) => {
               <Column
                 field="unit_price_tax_incl"
                 header="P/U (€)"
-                body={(data) => data.unit_price_tax_incl.toFixed(2)}
+                body={(data) => formatCurrencyES(data.unit_price_tax_incl)}
                 style={{ textAlign: "right" }}
               />
               <Column
                 header="Total (€)"
                 body={(rowData) =>
-                  (
+                  formatCurrencyES(
                     rowData.unit_price_tax_incl * rowData.product_quantity
-                  ).toFixed(2)
+                  )
                 }
                 style={{ textAlign: "right" }}
               />
@@ -214,7 +215,7 @@ const ReprintModal = ({ isOpen, onClose }) => {
                   <Column
                     field="value"
                     header="Valor"
-                    body={(data) => data.value.toFixed(2) + " €"}
+                    body={(data) => formatCurrencyES(data.value)}
                     style={{ textAlign: "right" }}
                   />
                 </DataTable>
@@ -481,7 +482,7 @@ const ReprintModal = ({ isOpen, onClose }) => {
             <Column
               field="total_paid"
               header="Total"
-              body={(data) => data.total_paid?.toFixed(2)}
+              body={(data) => formatCurrencyES(data.total_paid)}
               style={{
                 width: "100px",
                 textAlign: "center",

--- a/src/components/modals/returns/ReturnsExchangesModal.jsx
+++ b/src/components/modals/returns/ReturnsExchangesModal.jsx
@@ -13,6 +13,7 @@ import getApiBaseUrl from "../../../utils/getApiBaseUrl";
 import generateTicket from "../../../utils/ticket";
 import { ConfigContext } from "../../../contexts/ConfigContext";
 import { useEmployeesDictionary } from "../../../hooks/useEmployeesDictionary";
+import { formatCurrencyES } from "../../../utils/formatters";
 
 const ReturnsExchangesModal = ({ isOpen, onClose, onAddProduct }) => {
   const [orderId, setOrderId] = useState("");
@@ -622,7 +623,7 @@ const ReturnsExchangesModal = ({ isOpen, onClose, onAddProduct }) => {
                             opacity: "0.8",
                           }}
                         >
-                          {originalPrice.toFixed(2)} €
+                          {formatCurrencyES(originalPrice)}
                         </span>
                         <br />
                         <span
@@ -631,12 +632,12 @@ const ReturnsExchangesModal = ({ isOpen, onClose, onAddProduct }) => {
                             fontWeight: "bold",
                           }}
                         >
-                          {row.reduction_amount_tax_incl.toFixed(2)} €
+                          {formatCurrencyES(row.reduction_amount_tax_incl)}
                         </span>
                       </div>
                     );
                   }
-                  return `${originalPrice.toFixed(2)} €`;
+                  return formatCurrencyES(originalPrice);
                 }}
               />
               <Column
@@ -668,7 +669,7 @@ const ReturnsExchangesModal = ({ isOpen, onClose, onAddProduct }) => {
                             opacity: "0.8",
                           }}
                         >
-                          {originalTotal.toFixed(2)} €
+                          {formatCurrencyES(originalTotal)}
                         </span>
                         <br />
                         <span
@@ -677,12 +678,12 @@ const ReturnsExchangesModal = ({ isOpen, onClose, onAddProduct }) => {
                             fontWeight: "bold",
                           }}
                         >
-                          {discountedTotal.toFixed(2)} €
+                          {formatCurrencyES(discountedTotal)}
                         </span>
                       </div>
                     );
                   }
-                  return `${originalTotal.toFixed(2)} €`;
+                  return formatCurrencyES(originalTotal);
                 }}
               />
               <Column
@@ -744,7 +745,7 @@ const ReturnsExchangesModal = ({ isOpen, onClose, onAddProduct }) => {
                         <td className="py-2">{disc.code}</td>
                         <td className="py-2">{disc.name}</td>
                         <td className="py-2 text-right">
-                          {disc.value.toFixed(2)} €
+                          {formatCurrencyES(disc.value)}
                         </td>
                       </tr>
                     ))}

--- a/src/components/reports/NewSalesReportModal.jsx
+++ b/src/components/reports/NewSalesReportModal.jsx
@@ -11,6 +11,7 @@ import { useShopsDictionary } from "../../hooks/useShopsDictionary";
 import { ConfigContext } from "../../contexts/ConfigContext";
 import { formatShortDate } from "../../utils/dateUtils";
 import generateSessionsPdf from "../../utils/generateSessionsPdf";
+import { formatCurrencyES } from "../../utils/formatters";
 
 const NewSalesReportModal = ({ isOpen, onClose, inlineMode = false }) => {
   const apiFetch = useApiFetch();
@@ -115,18 +116,18 @@ const NewSalesReportModal = ({ isOpen, onClose, inlineMode = false }) => {
       const tbizum = parseFloat(s.total_bizum) || 0;
       return {
         ...s,
-        total_cash: tc,
-        total_card: tcard,
-        total_bizum: tbizum,
-        total: tc + tcard + tbizum,
+        total_cash: +tc.toFixed(2),
+        total_card: +tcard.toFixed(2),
+        total_bizum: +tbizum.toFixed(2),
+        total: +(tc + tcard + tbizum).toFixed(2),
       };
     });
 
     const totals = rows.reduce(
       (acc, r) => {
-        acc.total_cash += r.total_cash;
-        acc.total_card += r.total_card;
-        acc.total_bizum += r.total_bizum;
+        acc.total_cash = +(acc.total_cash + r.total_cash).toFixed(2);
+        acc.total_card = +(acc.total_card + r.total_card).toFixed(2);
+        acc.total_bizum = +(acc.total_bizum + r.total_bizum).toFixed(2);
         return acc;
       },
       { total_cash: 0, total_card: 0, total_bizum: 0 }
@@ -138,7 +139,7 @@ const NewSalesReportModal = ({ isOpen, onClose, inlineMode = false }) => {
         total_cash: totals.total_cash,
         total_card: totals.total_card,
         total_bizum: totals.total_bizum,
-        total: totals.total_cash + totals.total_card + totals.total_bizum,
+        total: +(totals.total_cash + totals.total_card + totals.total_bizum).toFixed(2),
         isTotal: true,
       });
     }
@@ -186,10 +187,34 @@ const NewSalesReportModal = ({ isOpen, onClose, inlineMode = false }) => {
           style={{ textAlign: "center", width: "120px" }}
           alignHeader="center"
         ></Column>
-        <Column field="total_cash" header="Total Efectivo" style={{ textAlign: "center", width: "120px" }} alignHeader="center"></Column>
-        <Column field="total_card" header="Total Tarjeta" style={{ textAlign: "center", width: "120px" }} alignHeader="center"></Column>
-        <Column field="total_bizum" header="Total Bizum" style={{ textAlign: "center", width: "120px" }} alignHeader="center"></Column>
-        <Column field="total" header="Total" style={{ textAlign: "center", width: "120px" }} alignHeader="center"></Column>
+        <Column
+          field="total_cash"
+          header="Total Efectivo"
+          style={{ textAlign: "center", width: "120px" }}
+          alignHeader="center"
+          body={(row) => formatCurrencyES(row.total_cash)}
+        ></Column>
+        <Column
+          field="total_card"
+          header="Total Tarjeta"
+          style={{ textAlign: "center", width: "120px" }}
+          alignHeader="center"
+          body={(row) => formatCurrencyES(row.total_card)}
+        ></Column>
+        <Column
+          field="total_bizum"
+          header="Total Bizum"
+          style={{ textAlign: "center", width: "120px" }}
+          alignHeader="center"
+          body={(row) => formatCurrencyES(row.total_bizum)}
+        ></Column>
+        <Column
+          field="total"
+          header="Total"
+          style={{ textAlign: "center", width: "120px" }}
+          alignHeader="center"
+          body={(row) => formatCurrencyES(row.total)}
+        ></Column>
       </DataTable>
     </Dialog>
   );

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -1,0 +1,19 @@
+export const formatCurrencyES = (value) => {
+  const number = typeof value === 'number' ? value : parseFloat(value || 0);
+  return new Intl.NumberFormat('es-ES', {
+    style: 'currency',
+    currency: 'EUR',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+    .format(number)
+    .replace(/\u00A0/, ' ');
+};
+
+export const formatNumberES = (value) => {
+  const number = typeof value === 'number' ? value : parseFloat(value || 0);
+  return new Intl.NumberFormat('es-ES', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(number);
+};


### PR DESCRIPTION
## Summary
- add utilities for euro/currency formatting
- format CloseCashRegisterForm totals and inputs
- show monetary values in DiscountModal, OpenPosModal, ListCashRegisterModal
- ensure NewSalesReportModal sums round to two decimals
- format order totals across modals (online orders, reprint, returns)

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68788d4597ac83319167d0b400df8628